### PR TITLE
feat: 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.4.0 - (Malachite Vienna) - April 2019
 
 - new CLI commands mc starter-ts and mc starter-js for starter projects
+- added version to user-agent
 
 ## Bugfixes 3.4.0
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Mindsphere V3 IoT model requires that you create an asset type and aspect types 
 
 ![assetype](images/types.png)
 
-More information about [MindSphere Data Model](http://go.siemens.net/39453207).
+More information about [MindSphere Data Model](http://bit.ly/2IgVB9T).
 
 ### Step 1: Create an asset
 
@@ -113,7 +113,7 @@ Create an agent in Asset Manager of type core.MindConnectLib create initial JSON
 }
 ```
 
-More Information about [core.MindConnectLib](http://go.siemens.net/41963280) configuration.
+More Information about [core.MindConnectLib](http://bit.ly/2HZ2ehE) configuration.
 
 ### Step 3 : Create an agent
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindconnect/mindconnect-nodejs",
-  "version": "3.4.0-1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mindconnect/mindconnect-nodejs",
-    "version": "3.4.0-1",
+    "version": "3.4.0",
     "description": "MindConnect Library for NodeJS (community based)",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
## 3.4.0 - (Malachite Vienna) - April 2019

- new CLI commands mc starter-ts and mc starter-js for starter projects
- added version to user-agent

## Bugfixes 3.4.0

- refactored the CLI commands to separate files
- made lock private in mindconnect storage
- references upgrade
