### PR TITLE
feat(mindconnect-agent): FileUpload with Buffer Parameter, and multipart-upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@
 - mindconnect-agent: the MindSphere path name can be configured (#23)
 - mindconnect-agent: deprecated  (#23)
 - SDK: started a SDK for the new commands which require additional mindsphere APIs 
-- SDK: the SDK will be extracted to a separate package in the version major version (4.0.0)
+- SDK: the SDK will be extracted to a separate package in the future major version (4.0.0)
 - CLI: the CLI will be extracted to a separate package in the future major version (4.0.0)
 
 ## Bugfixes and improvements 3.5.0
 
 - CLI Command: upload-timeseries - improved help and error messages during parsing #20
 
-## Contributions <3
+## Contributions :heart: <3
 
 - Thanks to ahmedi92 and goko for the contributions on this version. You rock!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,27 @@
 - CLI Command: prepare-bulk - creates a template directory for timeseries (bulk) upload
 - CLI Command: run-bulk - runs the timeseries (bulk) upload jobs
 - CLI Command: check-bulk - checks the progress of the upload jobs
+- mindconnect-agent: created new UploadFile method capable of running the multipart upload (#4)
+- mindconnect-agent: the UploadFile can now take a buffer additionally to file (#23)
+- mindconnect-agent: the MindSphere path name can be configured (#23)
+- mindconnect-agent: deprecated  (#23)
+- SDK: started a SDK for the new commands which require additional mindsphere APIs 
+- SDK: the SDK will be extracted to a separate package in the version major version (4.0.0)
+- CLI: the CLI will be extracted to a separate package in the future major version (4.0.0)
 
 ## Bugfixes and improvements 3.5.0
 
 - CLI Command: upload-timeseries - improved help and error messages during parsing #20
+
+## Contributions <3
+
+- Thanks to ahmedi92 and goko for the contributions on this version. You rock!
+
+## Announcements
+
+- SDK: the SDK will be extracted to a separate package in the version major version (4.0.0)
+- CLI: the CLI will be extracted to a separate package in the future major version (4.0.0)
+- We <3 contributions! We are working on the legal framework to let outside (non-Siemens collabarators) contribute. Stay tuned :)
 
 ## 3.4.0 - (Malachite Vienna) - April 2019
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindconnect/mindconnect-nodejs",
-  "version": "3.5.0-4",
+  "version": "3.5.0-5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mindconnect/mindconnect-nodejs",
-    "version": "3.5.0-4",
+    "version": "3.5.0-5",
     "description": "MindConnect Library for NodeJS (community based)",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",

--- a/src/api/mindconnect-agent.ts
+++ b/src/api/mindconnect-agent.ts
@@ -11,7 +11,6 @@ import { bulkDataTemplate, dataTemplate } from "./mindconnect-template";
 import { dataValidator, eventValidator } from "./mindconnect-validators";
 import { MultipartUploader, optionalParameters } from "./sdk/common/multipart-uploader";
 import _ = require("lodash");
-const mime = require("mime-types");
 const log = debug("mindconnect-agent");
 /**
  * MindConnect Agent implements the V3 of the Mindsphere API.

--- a/src/api/mindconnect-agent.ts
+++ b/src/api/mindconnect-agent.ts
@@ -361,6 +361,20 @@ export class MindConnectAgent extends AgentAuth {
         return <boolean>result;
     }
 
+    /**
+     * Upload file to MindSphere IOTFileService
+     *
+     * @param {string} entityId - asset id or agent.ClientId() for agent
+     * @param {string} filepath - mindsphere file path
+     * @param {(string | Buffer)} file - local path or Buffer
+     * @param {optionalParameters} [optional] - optional parameters: enable chunking, define retries etc.
+     * @returns {Promise<string>} - md5 hash of the file
+     *
+     * @memberOf MindConnectAgent
+     *
+     * @example await agent.UploadFile (agent.GetClientId(), "some/mindsphere/path/file.txt", "file.txt");
+     * @example await agent.UploadFile (agent.GetClientId(), "some/other/path/10MB.bin", "bigFile.bin",{chunked:true, retry:5});
+     */
     public async UploadFile(
         entityId: string,
         filepath: string,
@@ -383,7 +397,7 @@ export class MindConnectAgent extends AgentAuth {
      * @param {boolean} [chunk=true]  if this is set to false the system will only upload smaller files
      * @param {string} [entityId] entityid can be used to define the asset for upload, otherwise the agent is used.
      * @param {number} [chunkSize=8 * 1024 * 1024]  - at the moment 8MB as per restriction of mindgate
-     * @param {number} [maxSockets=3] - maxSockets for http Upload -
+     * @param {number} [maxSockets=3] - maxSockets for http Upload - number of parallel multipart uploads
      * @returns {Promise<string>} md5 hash of the uploaded file
      *
      * @memberOf MindConnectAgent
@@ -399,7 +413,6 @@ export class MindConnectAgent extends AgentAuth {
         filePath?: string
     ): Promise<string> {
         const clientId = entityId || this.ClientId();
-
         const filepath = filePath || (file instanceof Buffer ? "no-filepath-for-buffer" : path.basename(file));
 
         return await this.UploadFile(clientId, filepath, file, {

--- a/src/api/mindconnect-agent.ts
+++ b/src/api/mindconnect-agent.ts
@@ -3,15 +3,16 @@ import * as ajv from "ajv";
 import * as crypto from "crypto";
 import * as debug from "debug";
 import * as fs from "fs";
-import * as http from "http";
 import fetch from "node-fetch";
 import * as path from "path";
+import * as stream from "stream";
 import "url-search-params-polyfill";
 import { DataSourceConfiguration, Mapping, retry } from "..";
 import { AgentAuth } from "./agent-auth";
 import { BaseEvent, DataPointValue, TimeStampedDataPoint } from "./mindconnect-models";
 import { bulkDataTemplate, dataTemplate } from "./mindconnect-template";
 import { dataValidator, eventValidator } from "./mindconnect-validators";
+import { throwError } from "./utils";
 const mime = require("mime-types");
 const log = debug("mindconnect-agent");
 /**
@@ -21,7 +22,6 @@ const log = debug("mindconnect-agent");
  * @class MindConnectAgent
  */
 export class MindConnectAgent extends AgentAuth {
-
     public ClientId() {
         return this._configuration.content.clientId || "not defined yet";
     }
@@ -45,11 +45,9 @@ export class MindConnectAgent extends AgentAuth {
     public HasDataSourceConfiguration(): boolean {
         if (!this._configuration.dataSourceConfiguration) {
             return false;
-        }
-        else if (!this._configuration.dataSourceConfiguration.configurationId) {
+        } else if (!this._configuration.dataSourceConfiguration.configurationId) {
             return false;
-        }
-        else {
+        } else {
             return true;
         }
     }
@@ -64,7 +62,6 @@ export class MindConnectAgent extends AgentAuth {
         return this._configuration.mappings ? true : false;
     }
 
-
     /**
      * Stores the configuration in the mindsphere.
      *
@@ -78,37 +75,45 @@ export class MindConnectAgent extends AgentAuth {
      * @returns {Promise<DataSourceConfiguration>}
      * @memberof MindConnectAgent
      */
-    public async PutDataSourceConfiguration(dataSourceConfiguration: DataSourceConfiguration, ignoreEtag: boolean = true): Promise<DataSourceConfiguration> {
+    public async PutDataSourceConfiguration(
+        dataSourceConfiguration: DataSourceConfiguration,
+        ignoreEtag: boolean = true
+    ): Promise<DataSourceConfiguration> {
         await this.RenewToken();
-        if (!this._accessToken)
-            throw new Error("The agent doesn't have a valid access token.");
-        if (!this._configuration.content.clientId)
-            throw new Error("No client id in the configuration of the agent.");
+        if (!this._accessToken) throw new Error("The agent doesn't have a valid access token.");
+        if (!this._configuration.content.clientId) throw new Error("No client id in the configuration of the agent.");
 
         let eTag: number = 0;
 
         if (this._configuration.dataSourceConfiguration && this._configuration.dataSourceConfiguration.eTag) {
             eTag = parseInt(this._configuration.dataSourceConfiguration.eTag);
-            if (isNaN(eTag))
-                throw new Error("Invalid eTag in configuration!");
+            if (isNaN(eTag)) throw new Error("Invalid eTag in configuration!");
         }
 
         if (!ignoreEtag) {
-            if (!dataSourceConfiguration.eTag)
-                throw new Error("There is no eTag in the provided configuration!");
+            if (!dataSourceConfiguration.eTag) throw new Error("There is no eTag in the provided configuration!");
             eTag = parseInt(dataSourceConfiguration.eTag);
-            if (isNaN(eTag))
-                throw new Error("Invalid eTag in provided configuration!");
-
+            if (isNaN(eTag)) throw new Error("Invalid eTag in provided configuration!");
         }
 
-        const headers = { ...this._apiHeaders, "Authorization": `Bearer ${this._accessToken.access_token}`, "If-Match": eTag.toString() };
-        const url = `${this._configuration.content.baseUrl}/api/agentmanagement/v3/agents/${this._configuration.content.clientId}/dataSourceConfiguration`;
+        const headers = {
+            ...this._apiHeaders,
+            Authorization: `Bearer ${this._accessToken.access_token}`,
+            "If-Match": eTag.toString()
+        };
+        const url = `${this._configuration.content.baseUrl}/api/agentmanagement/v3/agents/${
+            this._configuration.content.clientId
+        }/dataSourceConfiguration`;
 
         log(`PutDataSourceConfiguration Headers ${JSON.stringify(headers)} Url ${url} eTag ${eTag}`);
 
         try {
-            const response = await fetch(url, { method: "PUT", body: JSON.stringify(dataSourceConfiguration), headers: headers, agent: this._proxyHttpAgent });
+            const response = await fetch(url, {
+                method: "PUT",
+                body: JSON.stringify(dataSourceConfiguration),
+                headers: headers,
+                agent: this._proxyHttpAgent
+            });
             const json = await response.json();
             if (!response.ok) {
                 throw new Error(`${response.statusText} ${JSON.stringify(json)}`);
@@ -129,13 +134,13 @@ export class MindConnectAgent extends AgentAuth {
 
     public async GetDataSourceConfiguration(): Promise<DataSourceConfiguration> {
         await this.RenewToken();
-        if (!this._accessToken)
-            throw new Error("The agent doesn't have a valid access token.");
-        if (!this._configuration.content.clientId)
-            throw new Error("No client id in the configuration of the agent.");
+        if (!this._accessToken) throw new Error("The agent doesn't have a valid access token.");
+        if (!this._configuration.content.clientId) throw new Error("No client id in the configuration of the agent.");
 
-        const headers = { ...this._apiHeaders, "Authorization": `Bearer ${this._accessToken.access_token}` };
-        const url = `${this._configuration.content.baseUrl}/api/agentmanagement/v3/agents/${this._configuration.content.clientId}/dataSourceConfiguration`;
+        const headers = { ...this._apiHeaders, Authorization: `Bearer ${this._accessToken.access_token}` };
+        const url = `${this._configuration.content.baseUrl}/api/agentmanagement/v3/agents/${
+            this._configuration.content.clientId
+        }/dataSourceConfiguration`;
 
         log(`GetDataSourceConfiguration Headers ${JSON.stringify(headers)} Url ${url}`);
 
@@ -161,16 +166,15 @@ export class MindConnectAgent extends AgentAuth {
     }
 
     public async GetDataMappings(): Promise<Array<Mapping>> {
-
         await this.RenewToken();
-        if (!this._accessToken)
-            throw new Error("The agent doesn't have a valid access token.");
-        if (!this._configuration.content.clientId)
-            throw new Error("No client id in the configuration of the agent.");
+        if (!this._accessToken) throw new Error("The agent doesn't have a valid access token.");
+        if (!this._configuration.content.clientId) throw new Error("No client id in the configuration of the agent.");
 
-        const headers = { ...this._apiHeaders, "Authorization": `Bearer ${this._accessToken.access_token}` };
-        const agentFilter = encodeURIComponent(JSON.stringify({ "agentId": `${this._configuration.content.clientId}` }));
-        const url = `${this._configuration.content.baseUrl}/api/mindconnect/v3/dataPointMappings?filter=${agentFilter}&size=2000`;
+        const headers = { ...this._apiHeaders, Authorization: `Bearer ${this._accessToken.access_token}` };
+        const agentFilter = encodeURIComponent(JSON.stringify({ agentId: `${this._configuration.content.clientId}` }));
+        const url = `${
+            this._configuration.content.baseUrl
+        }/api/mindconnect/v3/dataPointMappings?filter=${agentFilter}&size=2000`;
 
         log(`GetDataSourceConfiguration Headers ${JSON.stringify(headers)} Url ${url}`);
         try {
@@ -194,21 +198,23 @@ export class MindConnectAgent extends AgentAuth {
     }
 
     public async PutDataMappings(mappings: Mapping[]): Promise<boolean> {
-
         await this.RenewToken();
-        if (!this._accessToken)
-            throw new Error("The agent doesn't have a valid access token.");
-        if (!this._configuration.content.clientId)
-            throw new Error("No client id in the configuration of the agent.");
+        if (!this._accessToken) throw new Error("The agent doesn't have a valid access token.");
+        if (!this._configuration.content.clientId) throw new Error("No client id in the configuration of the agent.");
 
-        const headers = { ...this._apiHeaders, "Authorization": `Bearer ${this._accessToken.access_token}` };
+        const headers = { ...this._apiHeaders, Authorization: `Bearer ${this._accessToken.access_token}` };
         const url = `${this._configuration.content.baseUrl}/api/mindconnect/v3/dataPointMappings`;
 
         log(`GetDataSourceConfiguration Headers ${JSON.stringify(headers)} Url ${url}`);
 
         for (const mapping of mappings) {
             log(`Storing mapping ${mapping}`);
-            const response = await fetch(url, { method: "POST", body: JSON.stringify(mapping), headers: headers, agent: this._proxyHttpAgent });
+            const response = await fetch(url, {
+                method: "POST",
+                body: JSON.stringify(mapping),
+                headers: headers,
+                agent: this._proxyHttpAgent
+            });
             const json = await response.json();
             try {
                 if (!response.ok) {
@@ -217,7 +223,6 @@ export class MindConnectAgent extends AgentAuth {
                 if (!(response.status >= 200 && response.status <= 299)) {
                     throw new Error(`invalid response ${JSON.stringify(response)}`);
                 }
-
             } catch (err) {
                 log(err);
                 throw new Error(`Network error occured ${err.message}`);
@@ -239,14 +244,15 @@ export class MindConnectAgent extends AgentAuth {
      * @returns {Promise<boolean>}
      * @memberof MindConnectAgent
      */
-    public async PostEvent(event: BaseEvent, timeStamp: Date = new Date(), validateModel: boolean = true): Promise<boolean> {
-
+    public async PostEvent(
+        event: BaseEvent,
+        timeStamp: Date = new Date(),
+        validateModel: boolean = true
+    ): Promise<boolean> {
         await this.RenewToken();
-        if (!this._accessToken)
-            throw new Error("The agent doesn't have a valid access token.");
+        if (!this._accessToken) throw new Error("The agent doesn't have a valid access token.");
 
-
-        const headers = { ...this._apiHeaders, "Authorization": `Bearer ${this._accessToken.access_token}` };
+        const headers = { ...this._apiHeaders, Authorization: `Bearer ${this._accessToken.access_token}` };
         // const url = `${this._configuration.content.baseUrl}/api/mindconnect/v3/exchange`;
         const url = `${this._configuration.content.baseUrl}/api/eventmanagement/v3/events`;
         log(`GetDataSourceConfiguration Headers ${JSON.stringify(headers)} Url ${url}`);
@@ -267,7 +273,6 @@ export class MindConnectAgent extends AgentAuth {
         return <boolean>result;
     }
 
-
     /**
      * Post Data Point Values to the Exchange Endpoint
      *
@@ -280,14 +285,14 @@ export class MindConnectAgent extends AgentAuth {
      * @returns {Promise<boolean>}
      * @memberof MindConnectAgent
      */
-    public async PostData(dataPoints: DataPointValue[], timeStamp: Date = new Date(), validateModel: boolean = true): Promise<boolean> {
-
-
+    public async PostData(
+        dataPoints: DataPointValue[],
+        timeStamp: Date = new Date(),
+        validateModel: boolean = true
+    ): Promise<boolean> {
         await this.RenewToken();
-        if (!this._accessToken)
-            throw new Error("The agent doesn't have a valid access token.");
-        if (!this._configuration.content.clientId)
-            throw new Error("No client id in the configuration of the agent.");
+        if (!this._accessToken) throw new Error("The agent doesn't have a valid access token.");
+        if (!this._configuration.content.clientId) throw new Error("No client id in the configuration of the agent.");
         if (!this._configuration.dataSourceConfiguration)
             throw new Error("No data source configuration for the agent.");
         if (!this._configuration.dataSourceConfiguration.configurationId)
@@ -299,28 +304,31 @@ export class MindConnectAgent extends AgentAuth {
             if (!isValid) {
                 throw new Error(`Data doesn't match the configuration! Errors: ${JSON.stringify(validator.errors)}`);
             }
-
         }
 
-        const headers = { ...this._multipartHeaders, "Authorization": `Bearer ${this._accessToken.access_token}` };
+        const headers = { ...this._multipartHeaders, Authorization: `Bearer ${this._accessToken.access_token}` };
         const url = `${this._configuration.content.baseUrl}/api/mindconnect/v3/exchange`;
 
         log(`GetDataSourceConfiguration Headers ${JSON.stringify(headers)} Url ${url}`);
 
-        const dataMessage = dataTemplate(timeStamp, dataPoints, this._configuration.dataSourceConfiguration.configurationId);
+        const dataMessage = dataTemplate(
+            timeStamp,
+            dataPoints,
+            this._configuration.dataSourceConfiguration.configurationId
+        );
         log(dataMessage);
 
         const result = await this.SendMessage("POST", url, dataMessage, headers);
         return <boolean>result;
     }
 
-    public async BulkPostData(timeStampedDataPoints: TimeStampedDataPoint[], validateModel: boolean = true): Promise<boolean> {
-
+    public async BulkPostData(
+        timeStampedDataPoints: TimeStampedDataPoint[],
+        validateModel: boolean = true
+    ): Promise<boolean> {
         await this.RenewToken();
-        if (!this._accessToken)
-            throw new Error("The agent doesn't have a valid access token.");
-        if (!this._configuration.content.clientId)
-            throw new Error("No client id in the configuration of the agent.");
+        if (!this._accessToken) throw new Error("The agent doesn't have a valid access token.");
+        if (!this._configuration.content.clientId) throw new Error("No client id in the configuration of the agent.");
         if (!this._configuration.dataSourceConfiguration)
             throw new Error("No data source configuration for the agent.");
         if (!this._configuration.dataSourceConfiguration.configurationId)
@@ -333,129 +341,261 @@ export class MindConnectAgent extends AgentAuth {
                 const element = timeStampedDataPoints[index];
                 const isValid = await validator(element.values);
                 if (!isValid) {
-                    throw new Error(`Data doesn't match the configuration! Errors: ${JSON.stringify(validator.errors)}`);
+                    throw new Error(
+                        `Data doesn't match the configuration! Errors: ${JSON.stringify(validator.errors)}`
+                    );
                 }
             }
         }
 
-        const headers = { ...this._multipartHeaders, "Authorization": `Bearer ${this._accessToken.access_token}` };
+        const headers = { ...this._multipartHeaders, Authorization: `Bearer ${this._accessToken.access_token}` };
         const url = `${this._configuration.content.baseUrl}/api/mindconnect/v3/exchange`;
 
         log(`GetDataSourceConfiguration Headers ${JSON.stringify(headers)} Url ${url}`);
 
-        const bulkDataMessage = bulkDataTemplate(timeStampedDataPoints, this._configuration.dataSourceConfiguration.configurationId);
+        const bulkDataMessage = bulkDataTemplate(
+            timeStampedDataPoints,
+            this._configuration.dataSourceConfiguration.configurationId
+        );
         log(bulkDataMessage);
 
         const result = await this.SendMessage("POST", url, bulkDataMessage, headers);
         return <boolean>result;
     }
 
+    public async UploadFile(
+        entityId: string,
+        filepath: string,
+        file: string | Buffer,
+        optional?: {
+            part?: number;
+            "If-Match"?: number;
+            timestamp?: Date;
+            description?: string;
+            type?: string;
+            chunkSize?: number;
+            retry?: number;
+            chunk?: boolean;
+        }
+    ): Promise<string> {
+        optional = optional || {};
+        const chunkSize = optional.chunkSize || 8 * 1024 * 1024;
+        const fileLength = file instanceof Buffer ? file.length : fs.statSync(file).size;
+        const totalChunks = this.getTotalChunks(fileLength, chunkSize, optional);
+
+        const shortFileName = path.basename(filepath);
+        const fileInfo = {
+            description: optional.description || shortFileName,
+            timeStamp: this.getTimeStamp(optional, file),
+            fileType: this.getFileType(optional, file),
+            uploadPath: filepath,
+            totalChunks: totalChunks,
+            entityId: entityId
+        };
+
+        const mystream = this.getStreamFromFile(file, chunkSize);
+        const hash = crypto.createHash("md5");
+        const promises: any[] = [];
+
+        let current = new Uint8Array(0);
+        let chunks = 0;
+
+        return new Promise((resolve, reject) => {
+            mystream
+                .on("error", err => reject(err))
+                .on("data", (data: Buffer) => {
+                    if (current.byteLength + data.byteLength < chunkSize) {
+                        current = this.addDataToBuffer(current, data);
+                    } else {
+                        if (current.byteLength > 0) {
+                            const currentBuffer = Buffer.from(current);
+                            promises.push(
+                                this.UploadChunk({
+                                    ...fileInfo,
+                                    chunks: ++chunks,
+                                    buffer: currentBuffer
+                                })
+                            );
+                        }
+                        current = new Uint8Array(data.byteLength);
+                        current.set(data, 0);
+                    }
+                })
+                .on("end", () => {
+                    if (current.byteLength > 0) {
+                        const currentBuffer = Buffer.from(current);
+                        promises.push(
+                            this.UploadChunk({
+                                ...fileInfo,
+                                chunks: ++chunks,
+                                buffer: currentBuffer
+                            })
+                        );
+                    }
+                })
+                .pipe(hash)
+                .once("finish", async () => {
+                    try {
+                        await Promise.all(promises);
+                        log(promises);
+                        resolve(hash.read().toString("hex"));
+                    } catch (err) {
+                        reject(new Error("upload failed" + err));
+                    }
+                });
+        });
+    }
+
+    private getTotalChunks(
+        fileLength: number,
+        chunkSize: number,
+        optional: {
+            part?: number | undefined;
+            "If-Match"?: number | undefined;
+            timestamp?: Date | undefined;
+            description?: string | undefined;
+            type?: string | undefined;
+            chunkSize?: number | undefined;
+            retry?: number | undefined;
+            chunk?: boolean | undefined;
+        }
+    ) {
+        const totalChunks = Math.ceil(fileLength / chunkSize);
+        !optional.chunk && totalChunks > 1 && throwError("File is too big.");
+        optional.chunk && totalChunks > 1 && log("WARN: Chunking is experimental!");
+        return totalChunks;
+    }
+
+    private getTimeStamp(
+        optional: {
+            part?: number | undefined;
+            "If-Match"?: number | undefined;
+            timestamp?: Date | undefined;
+            description?: string | undefined;
+            type?: string | undefined;
+            chunkSize?: number | undefined;
+            retry?: number | undefined;
+            chunk?: boolean | undefined;
+        },
+        file: string | Buffer
+    ) {
+        return optional.timestamp || (file instanceof Buffer ? new Date() : fs.statSync(file).ctime);
+    }
+
+    private getFileType(
+        optional: {
+            part?: number | undefined;
+            "If-Match"?: number | undefined;
+            timestamp?: Date | undefined;
+            description?: string | undefined;
+            type?: string | undefined;
+            chunkSize?: number | undefined;
+            retry?: number | undefined;
+            chunk?: boolean | undefined;
+        },
+        file: string | Buffer
+    ) {
+        return (
+            optional.type ||
+            (file instanceof Buffer ? "application/octet-stream" : mime.lookup(file) || "application/octet-stream")
+        );
+    }
+
+    private getStreamFromFile(file: string | Buffer, chunksize: number) {
+        return file instanceof Buffer
+            ? (() => {
+                  const bufferStream = new stream.PassThrough({ highWaterMark: chunksize });
+                  for (let index = 0; index < file.length; ) {
+                      const end = Math.min(index + chunksize, file.length);
+                      bufferStream.write(file.slice(index, end));
+                      index = end;
+                  }
+                  bufferStream.end();
+                  return bufferStream;
+              })()
+            : fs.createReadStream(path.resolve(file), { highWaterMark: chunksize });
+    }
+
     /**
      * Uploads the file to mindsphere
      *
-     * @param {string} fileName filename
+     * @deprecated please use UploadFile method instead this method will be deleted in version 4.0.
+     *
+     * @param {string} file filename or buffer for upload
      * @param {string} fileType mime type (e.g. image/png)
      * @param {string} description description of the file
      * @param {boolean} [chunk=true]  if this is set to false the system will only upload smaller files
      * @param {string} [entityId] entityid can be used to define the asset for upload, otherwise the agent is used.
      * @param {number} [chunkSize=8 * 1024 * 1024]  - at the moment 8MB as per restriction of mindgate
-     * @param {number} [maxSockets=3] - maxSockets for http Upload
+     * @param {number} [maxSockets=3] - maxSockets for http Upload -
      * @returns {Promise<string>} md5 hash of the uploaded file
      *
      * @memberOf MindConnectAgent
      */
-    public async Upload(fileName: string, fileType: string, description: string, chunk: boolean = true, entityId?: string, chunkSize: number = 8 * 1024 * 1024, maxSockets: number = 3): Promise<string> {
-        http.globalAgent.maxSockets = maxSockets;
+    public async Upload(
+        file: string | Buffer,
+        fileType: string,
+        description: string,
+        chunk: boolean = true,
+        entityId?: string,
+        chunkSize: number = 8 * 1024 * 1024,
+        maxSockets: number = 3,
+        filePath?: string
+    ): Promise<string> {
+        const clientId = entityId || this.ClientId();
 
-        await this.RenewToken();
-        if (!this._accessToken || !this._accessToken.access_token)
-            throw new Error("The agent doesn't have a valid access token.");
-        const token = this._accessToken.access_token;
+        const filepath = filePath || (file instanceof Buffer ? "no-filepath-for-buffer" : path.basename(file));
 
-        if (!this._configuration.content.clientId)
-            throw new Error("No client id in the configuration of the agent.");
-
-        const promises: any[] = [];
-        const stats = fs.statSync(fileName);
-        const timeStamp = stats.ctime;
-
-        const totalChunks = Math.ceil(stats.size / chunkSize);
-        if (!chunk && totalChunks > 1) {
-            throw new Error("File is too big.");
-        } else if (chunk && totalChunks > 1) {
-            log("WARN: Chunking is experimental!");
-        }
-        const shortFileName = path.basename(fileName);
-        let chunks = 0;
-
-        if (!entityId) {
-            entityId = this._configuration.content.clientId;
-        }
-
-        if (!fileType) {
-            fileType = mime.lookup(fileName) || "application/octet-stream";
-        }
-
-        let current: Uint8Array = new Uint8Array(0);
-
-        const fileReadStream = fs.createReadStream(fileName, { "highWaterMark": chunkSize });
-        const hash = crypto.createHash("md5");
-        return new Promise((resolve, reject) => {
-            fileReadStream.on("data", (data: Buffer) => {
-
-                if (current.byteLength + data.byteLength < chunkSize) {
-                    const newLength = current.byteLength + data.byteLength;
-                    const newBuffer = new Uint8Array(newLength);
-                    newBuffer.set(current, 0);
-                    newBuffer.set(data, current.byteLength);
-                    current = newBuffer;
-                } else {
-                    if (current.byteLength > 0) {
-                        const currentBuffer = Buffer.from(current);
-                        promises.push(this.UploadChunk(token, description, ++chunks, totalChunks, fileType, timeStamp, shortFileName, "" + entityId, currentBuffer));
-                    }
-                    current = new Uint8Array(data.byteLength);
-                    current.set(data, 0);
-                }
-            }).on("error", err => {
-                reject(err);
-            }).on("end", () => {
-                if (current.byteLength > 0) {
-                    const currentBuffer = Buffer.from(current);
-                    promises.push(this.UploadChunk(token, description, ++chunks, totalChunks, fileType, timeStamp, shortFileName, "" + entityId, currentBuffer));
-                }
-            }).pipe(
-                hash
-            ).once("finish", async () => {
-                try {
-                    await Promise.all(promises);
-                    log(promises);
-                    resolve(hash.read().toString("hex"));
-                }
-                catch (err) {
-                    reject(new Error("upload failed" + err));
-                }
-            });
-
+        return await this.UploadFile(clientId, filepath, file, {
+            type: fileType,
+            description: description,
+            chunk: chunk,
+            chunkSize: chunkSize
         });
     }
 
+    private addDataToBuffer(current: Uint8Array, data: Buffer) {
+        const newLength = current.byteLength + data.byteLength;
+        const newBuffer = new Uint8Array(newLength);
+        newBuffer.set(current, 0);
+        newBuffer.set(data, current.byteLength);
+        current = newBuffer;
+        return current;
+    }
 
-    private async UploadChunk(token: string, description: string, chunks: number, totalChunks: number, fileType: string, timeStamp: Date, shortFileName: string, entityId: string, buffer: Uint8Array): Promise<boolean> {
+    private async UploadChunk({
+        description,
+        chunks,
+        totalChunks,
+        fileType,
+        timeStamp,
+        uploadPath,
+        entityId,
+        buffer
+    }: {
+        description: string;
+        chunks: number;
+        totalChunks: number;
+        fileType: string;
+        timeStamp: Date;
+        uploadPath: string;
+        entityId: string;
+        buffer: Uint8Array;
+    }): Promise<boolean> {
+        if (buffer.length <= 0) return false;
 
-        if (buffer.length <= 0)
-            return false;
+        const token = await this.GetAgentToken();
 
         const headers = {
             ...this._apiHeaders,
-            "Authorization": `Bearer ${token}`,
-            "description": description,
-            "type": totalChunks === 1 ? fileType : `${fileType}.chunked`,
-            "timestamp": timeStamp,
+            Authorization: `Bearer ${token}`,
+            description: description,
+            type: totalChunks === 1 ? fileType : `${fileType}.chunked`,
+            timestamp: timeStamp.toISOString(),
             "content-type": "application/octet-stream"
         };
 
-        const currentFileName = totalChunks === 1 ? shortFileName : `${shortFileName}.${chunks}.of.${totalChunks}`;
+        const currentFileName = totalChunks === 1 ? uploadPath : `${uploadPath}.${chunks}.of.${totalChunks}`;
         const url = `${this._configuration.content.baseUrl}/api/iotfile/v3/files/${entityId}/${currentFileName}`;
 
         if (this._configuration.urls && (<any>this._configuration.urls)[url]) {
@@ -473,13 +613,21 @@ export class MindConnectAgent extends AgentAuth {
         await retry(5, () => this.SaveConfig());
 
         return true;
-
     }
 
-
-    private async SendMessage(method: "POST" | "PUT", url: string, dataMessage: string | ArrayBuffer, headers: {}): Promise<string | boolean> {
+    private async SendMessage(
+        method: "POST" | "PUT",
+        url: string,
+        dataMessage: string | ArrayBuffer,
+        headers: {}
+    ): Promise<string | boolean> {
         try {
-            const response = await fetch(url, { method: method, body: dataMessage, headers: headers, agent: this._proxyHttpAgent });
+            const response = await fetch(url, {
+                method: method,
+                body: dataMessage,
+                headers: headers,
+                agent: this._proxyHttpAgent
+            });
             if (!response.ok) {
                 log({ method: method, body: dataMessage, headers: headers, agent: this._proxyHttpAgent });
                 log(response);
@@ -491,7 +639,6 @@ export class MindConnectAgent extends AgentAuth {
             if (response.status >= 200 && response.status <= 299) {
                 const etag = response.headers.get("eTag");
                 return etag !== null ? etag : true;
-
             } else {
                 throw new Error(`Error occured response status ${response.status} ${text}`);
             }

--- a/src/api/mindconnect-base.ts
+++ b/src/api/mindconnect-base.ts
@@ -1,4 +1,5 @@
 import * as debug from "debug";
+import fetch from "node-fetch";
 import { throwError } from "./utils";
 const HttpsProxyAgent = require("https-proxy-agent");
 const log = debug("mindconnect");

--- a/src/api/sdk/asset/asset-management.ts
+++ b/src/api/sdk/asset/asset-management.ts
@@ -13,6 +13,8 @@ export class AssetManagementClient extends SdkClient {
     ): Promise<AssetManagementModels.AssetTypeResource> {
         const result = await this.HttpAction({
             verb: "GET",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/assettypes/${typeId}?exploded=${exploded}`,
             additionalHeaders: { "If-Match": ifNoneMatch }
         });
@@ -23,6 +25,8 @@ export class AssetManagementClient extends SdkClient {
         checkAssetId(assetId);
         const result = await this.HttpAction({
             verb: "GET",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/assets/${assetId}`,
             message: "GetAsset"
         });
@@ -33,6 +37,8 @@ export class AssetManagementClient extends SdkClient {
         checkAssetId(assetId);
         const result = await this.HttpAction({
             verb: "GET",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/assets/${assetId}/aspects`,
             message: "GetAspects"
         });
@@ -43,6 +49,8 @@ export class AssetManagementClient extends SdkClient {
         checkAssetId(assetId);
         await this.HttpAction({
             verb: "PUT",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/assets/${assetId}`,
             body: asset,
             message: "PutAsset",
@@ -56,6 +64,8 @@ export class AssetManagementClient extends SdkClient {
     ): Promise<AssetManagementModels.AssetResourceWithHierarchyPath> {
         const result = await this.HttpAction({
             verb: "POST",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/assets`,
             body: asset,
             message: "PostAsset"
@@ -66,6 +76,8 @@ export class AssetManagementClient extends SdkClient {
     public async GetRootAsset(): Promise<AssetManagementModels.RootAssetResource> {
         const result = await this.HttpAction({
             verb: "GET",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/assets/root`,
             message: "PostAsset"
         });

--- a/src/api/sdk/common/multipart-uploader.ts
+++ b/src/api/sdk/common/multipart-uploader.ts
@@ -1,0 +1,3 @@
+export class MultipartUploader {
+    constructor(private renewToken: () => string) {}
+}

--- a/src/api/sdk/common/multipart-uploader.ts
+++ b/src/api/sdk/common/multipart-uploader.ts
@@ -298,15 +298,16 @@ export class MultipartUploader extends MindConnectBase {
     }
 
     /**
-     * The new upload file operation.
+     * Upload file to MindSphere IOTFileService
      *
-     * @param {string} entityId
-     * @param {string} filepath
-     * @param {(string | Buffer)} file
-     * @param {optionalParameters} [optional]
-     * @returns {Promise<string>}
+     * @param {string} entityId - asset id or agent.ClientId() for agent
+     * @param {string} filepath - mindsphere file path
+     * @param {(string | Buffer)} file - local path or Buffer
+     * @param {optionalParameters} [optional] - optional parameters: enable chunking, define retries etc.
+     * @returns {Promise<string>} - md5 hash of the file
      *
      * @memberOf MultipartUploader
+     *
      */
     public async UploadFile(
         entityId: string,

--- a/src/api/sdk/common/multipart-uploader.ts
+++ b/src/api/sdk/common/multipart-uploader.ts
@@ -1,3 +1,361 @@
-export class MultipartUploader {
-    constructor(private renewToken: () => string) {}
+import * as crypto from "crypto";
+import * as debug from "debug";
+import * as fs from "fs";
+import * as path from "path";
+import * as stream from "stream";
+import { MindConnectBase } from "../../mindconnect-base";
+import { IMindConnectConfiguration } from "../../mindconnect-models";
+import { throwError } from "../../utils";
+import _ = require("lodash");
+
+const mime = require("mime-types");
+const log = debug("multipart-uploader");
+
+export type optionalParameters = {
+    part?: number | undefined;
+    timestamp?: Date | undefined;
+    description?: string | undefined;
+    type?: string | undefined;
+    chunkSize?: number | undefined;
+    retry?: number | undefined;
+    chunk?: boolean | undefined;
+};
+
+type uploadChunkParameters = {
+    description: string;
+    chunks: number;
+    totalChunks: number;
+    fileType: string;
+    timeStamp: Date;
+    uploadPath: string;
+    entityId: string;
+    buffer: Uint8Array;
+    ifmatch?: number;
+};
+
+/**
+ * The multipart uploader handles the upload of the files to the mindsphere
+ * This class is shared between the MindConnectAgent and the IotFileClient
+ *
+ * @export
+ * @class MultipartUploader
+ * @extends {MindConnectBase}
+ */
+export class MultipartUploader extends MindConnectBase {
+    GetToken: () => Promise<string>;
+    getConfiguration: (() => IMindConnectConfiguration) | undefined;
+    gateway: () => string;
+    private getTotalChunks(fileLength: number, chunkSize: number, optional: optionalParameters) {
+        const totalChunks = Math.ceil(fileLength / chunkSize);
+        !optional.chunk && totalChunks > 1 && throwError("File is too big.");
+        optional.chunk && totalChunks > 1 && log("WARN: Chunking is experimental!");
+        return totalChunks;
+    }
+
+    private getTimeStamp(optional: optionalParameters, file: string | Buffer) {
+        return optional.timestamp || (file instanceof Buffer ? new Date() : fs.statSync(file).ctime);
+    }
+
+    private getFileType(optional: optionalParameters, file: string | Buffer) {
+        return (
+            optional.type ||
+            (file instanceof Buffer ? "application/octet-stream" : `${mime.lookup(file)}` || "application/octet-stream")
+        );
+    }
+
+    private getStreamFromFile(file: string | Buffer, chunksize: number) {
+        return file instanceof Buffer
+            ? (() => {
+                  const bufferStream = new stream.PassThrough({ highWaterMark: chunksize });
+                  for (let index = 0; index < file.length; ) {
+                      const end = Math.min(index + chunksize, file.length);
+                      bufferStream.write(file.slice(index, end));
+                      index = end;
+                  }
+                  bufferStream.end();
+                  return bufferStream;
+              })()
+            : fs.createReadStream(path.resolve(file), { highWaterMark: chunksize });
+    }
+
+    private addDataToBuffer(current: Uint8Array, data: Buffer) {
+        const newLength = current.byteLength + data.byteLength;
+        const newBuffer = new Uint8Array(newLength);
+        newBuffer.set(current, 0);
+        newBuffer.set(data, current.byteLength);
+        current = newBuffer;
+        return current;
+    }
+
+    private getBareUrl(url: string) {
+        const parsedUrl = new URL(url);
+        const bareUrl = url.replace(parsedUrl.search, "");
+        return bareUrl;
+    }
+
+    private fix_iotFileUpload_3_2_0(result: string | boolean, previousEtag: number | undefined) {
+        // ! guess etag for the upload
+        // ! in may 2019 mindsphere was not returning eTags for multipart uploads in the header
+        // ! but was still expecting them for the new upload
+        // ! this fix guesses the new value of the eTag
+        return typeof result === "boolean"
+            ? previousEtag !== undefined
+                ? (previousEtag + 1).toString()
+                : "0"
+            : result;
+    }
+
+    private setIfMatch(url: string, headers: any): number | undefined {
+        let result;
+        const bareUrl = this.getBareUrl(url);
+
+        (!this.getConfiguration || headers["If-Match"] !== undefined) &&
+            throwError("You have to set if-match if you are using this outside the MindConnectAgent");
+
+        if (this.getConfiguration) {
+            const config = this.getConfiguration() as any;
+            if (config.urls && config.urls[bareUrl]) {
+                const eTag = config.urls[bareUrl];
+                const etagNumber = parseInt(eTag);
+                result = etagNumber;
+                (<any>headers)["If-Match"] = etagNumber;
+            }
+        }
+        return result;
+    }
+
+    private addUrl(url: string, result: string) {
+        if (!this.getConfiguration) return;
+
+        const config = this.getConfiguration() as any;
+
+        if (!config.urls) {
+            config.urls = {};
+        }
+
+        const entry = this.getBareUrl(url);
+        config.urls[entry] = result;
+    }
+
+    private async MultipartOperation({
+        mode,
+        entityId,
+        uploadPath,
+        ifmatch,
+        description,
+        fileType,
+        timeStamp
+    }: {
+        mode: "start" | "complete" | "abort";
+        entityId: string;
+        description: string;
+        fileType: string;
+        uploadPath: string;
+        timeStamp: Date;
+        ifmatch?: number;
+    }) {
+        const url = `/api/iotfile/v3/files/${entityId}/${uploadPath}?upload=${mode}`;
+        const token = await this.GetToken();
+
+        const headers = {
+            description: description,
+            type: fileType,
+            timestamp: timeStamp.toISOString()
+        };
+
+        ifmatch && ((headers as any)["If-Match"] = ifmatch);
+        this.setIfMatch(url, headers);
+
+        const result = await this.HttpAction({
+            verb: "PUT",
+            authorization: token,
+            gateway: this.gateway(),
+            baseUrl: url,
+            octetStream: true,
+            additionalHeaders: headers,
+            noResponse: true,
+            returnHeaders: true,
+            body: Buffer.alloc(0)
+        });
+        return result;
+    }
+
+    private async UploadChunk({
+        description,
+        chunks,
+        totalChunks,
+        fileType,
+        timeStamp,
+        uploadPath,
+        entityId,
+        buffer,
+        ifmatch
+    }: uploadChunkParameters): Promise<boolean> {
+        if (buffer.length <= 0) return false;
+
+        const headers = {
+            description: description,
+            type: fileType,
+            timestamp: timeStamp.toISOString()
+        };
+
+        ifmatch && ((headers as any)["If-Match"] = ifmatch);
+
+        let part = totalChunks === 1 ? "" : `?part=${chunks}`;
+        if (part === `?part=${totalChunks}`) {
+            part = `?upload=complete`;
+        }
+
+        const url = `/api/iotfile/v3/files/${entityId}/${uploadPath}${part}`;
+        const previousEtag = this.setIfMatch(`${this.gateway}${url}`, headers);
+
+        const token = await this.GetToken();
+
+        const result = await this.HttpAction({
+            verb: "PUT",
+            baseUrl: url,
+            gateway: this.gateway(),
+            authorization: token,
+            body: buffer,
+            octetStream: true,
+            additionalHeaders: headers,
+            noResponse: true,
+            returnHeaders: true
+        });
+
+        // * only set the eTag after the upload is complete
+        if (totalChunks > 1 && !url.endsWith(`upload=complete`)) {
+            return true;
+        }
+        const newEtag = this.fix_iotFileUpload_3_2_0(!!result, previousEtag);
+        this.addUrl(url, newEtag);
+        return true;
+    }
+
+    public async UploadFile(
+        entityId: string,
+        filepath: string,
+        file: string | Buffer,
+        optional?: {
+            part?: number;
+            ifmatch?: number;
+            timestamp?: Date;
+            description?: string;
+            type?: string;
+            chunkSize?: number;
+            retry?: number;
+            chunk?: boolean;
+            paralelUploads?: number;
+        }
+    ): Promise<string> {
+        optional = optional || {};
+        const chunkSize = optional.chunkSize || 8 * 1024 * 1024;
+        optional.chunk &&
+            chunkSize < 5 * 1024 * 1024 &&
+            throwError("The chunk size must be at least 5 MB for multipart upload.");
+
+        const fileLength = file instanceof Buffer ? file.length : fs.statSync(file).size;
+        const totalChunks = this.getTotalChunks(fileLength, chunkSize, optional);
+
+        const shortFileName = path.basename(filepath);
+        const fileInfo = {
+            description: optional.description || shortFileName,
+            timeStamp: this.getTimeStamp(optional, file),
+            fileType: this.getFileType(optional, file),
+            uploadPath: filepath,
+            totalChunks: totalChunks,
+            entityId: entityId
+        };
+
+        optional.ifmatch && ((fileInfo as any)["If-Match"] = optional.ifmatch);
+
+        const mystream = this.getStreamFromFile(file, chunkSize);
+        const hash = crypto.createHash("md5");
+        const promises: any[] = [];
+
+        let current = new Uint8Array(0);
+        let chunks = 0;
+
+        // console.log(totalChunks);
+        optional.chunk &&
+            totalChunks > 1 &&
+            (await this.MultipartOperation({
+                mode: "start",
+                ...fileInfo
+            }));
+
+        return new Promise((resolve, reject) => {
+            mystream
+                .on("error", err => reject(err))
+                .on("data", async (data: Buffer) => {
+                    if (current.byteLength + data.byteLength < chunkSize) {
+                        current = this.addDataToBuffer(current, data);
+                    } else {
+                        if (current.byteLength > 0) {
+                            const currentBuffer = Buffer.from(current);
+                            promises.push(() =>
+                                this.UploadChunk({
+                                    ...fileInfo,
+                                    chunks: ++chunks,
+                                    buffer: currentBuffer
+                                })
+                            );
+                        }
+                        current = new Uint8Array(data.byteLength);
+                        current.set(data, 0);
+                    }
+                })
+                .on("end", () => {
+                    const currentBuffer = Buffer.from(current);
+                    promises.push(() =>
+                        this.UploadChunk({
+                            ...fileInfo,
+                            chunks: ++chunks,
+                            buffer: currentBuffer
+                        })
+                    );
+                })
+                .pipe(hash)
+                .once("finish", async () => {
+                    try {
+                        // * this is the last promise (for multipart) the one which completes the upload
+                        // * this has to be awaited last.
+                        const lastPromise = promises.pop();
+
+                        // * the chunks before last can be uploaded in paralell to mindsphere
+                        const maxParalellUploads = (optional && optional.paralelUploads) || 25;
+                        const splitedPromises = _.chunk(promises, maxParalellUploads);
+
+                        for (const partPromises of splitedPromises) {
+                            const uploadParts: any = [];
+                            partPromises.forEach(async f => {
+                                uploadParts.push(f());
+                            });
+
+                            await Promise.all(uploadParts);
+                        }
+                        // * for non-multipart-upload this is the only promise which is ever resolved
+                        await lastPromise();
+                        resolve(hash.read().toString("hex"));
+                    } catch (err) {
+                        reject(new Error("upload failed" + err));
+                    }
+                });
+        });
+    }
+
+    constructor({
+        getToken,
+        getConfiguration,
+        gateway
+    }: {
+        getToken: () => Promise<string>;
+        getConfiguration?: () => IMindConnectConfiguration;
+        gateway: () => string;
+    }) {
+        super();
+        this.GetToken = getToken;
+        this.gateway = gateway;
+        this.getConfiguration = getConfiguration;
+    }
 }

--- a/src/api/sdk/common/sdk-client.ts
+++ b/src/api/sdk/common/sdk-client.ts
@@ -7,7 +7,7 @@ export abstract class SdkClient extends CredentialAuth {
     protected async GetToken() {
         return await this.GetServiceToken();
     }
-    protected GetGateway() {
+    public GetGateway() {
         return this._gateway;
     }
 }

--- a/src/api/sdk/common/sdk-client.ts
+++ b/src/api/sdk/common/sdk-client.ts
@@ -1,7 +1,5 @@
 import { CredentialAuth } from "../../credential-auth";
 
-const debug = require("debug");
-
 export abstract class SdkClient extends CredentialAuth {
     protected async GetToken() {
         return await this.GetServiceToken();

--- a/src/api/sdk/common/sdk-client.ts
+++ b/src/api/sdk/common/sdk-client.ts
@@ -1,5 +1,6 @@
 import fetch from "node-fetch";
 import { CredentialAuth } from "../../credential-auth";
+import { throwError } from "../../utils";
 
 const debug = require("debug");
 const log = debug("sdk-client");
@@ -45,13 +46,10 @@ export abstract class SdkClient extends CredentialAuth {
                 request.body = octetStream ? body : JSON.stringify(body);
             }
             const response = await fetch(url, request);
-            if (!response.ok) {
-                throw new Error(`${response.statusText} ${await response.text()}`);
-            }
 
-            if (response.status < 200 || response.status > 299) {
-                throw new Error(`invalid response ${JSON.stringify(response)}`);
-            }
+            !response.ok && throwError(`${response.statusText} ${await response.text()}`);
+            (response.status < 200 || response.status > 299) &&
+                throwError(`invalid response ${JSON.stringify(response)}`);
 
             if (noResponse) {
                 if (returnHeaders) {

--- a/src/api/sdk/common/sdk-client.ts
+++ b/src/api/sdk/common/sdk-client.ts
@@ -1,7 +1,6 @@
 import { CredentialAuth } from "../../credential-auth";
 
 const debug = require("debug");
-const log = debug("sdk-client");
 
 export abstract class SdkClient extends CredentialAuth {
     protected async GetToken() {

--- a/src/api/sdk/common/sdk-client.ts
+++ b/src/api/sdk/common/sdk-client.ts
@@ -1,69 +1,13 @@
-import fetch from "node-fetch";
 import { CredentialAuth } from "../../credential-auth";
-import { throwError } from "../../utils";
 
 const debug = require("debug");
 const log = debug("sdk-client");
 
 export abstract class SdkClient extends CredentialAuth {
-    protected async HttpAction({
-        verb,
-        baseUrl,
-        body,
-        message,
-        octetStream,
-        additionalHeaders,
-        noResponse,
-        returnHeaders
-    }: {
-        verb: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
-        baseUrl: string;
-        body?: Object;
-        message?: string;
-        octetStream?: boolean;
-        additionalHeaders?: Object;
-        noResponse?: boolean;
-        returnHeaders?: boolean;
-    }): Promise<Object> {
-        await this.RenewToken();
-        if (!this._accessToken) {
-            throw new Error("no valid token");
-        }
-        additionalHeaders = additionalHeaders || {};
-        const apiheaders = octetStream ? this._octetStreamHeaders : this._apiHeaders;
-
-        const headers: any = {
-            ...apiheaders,
-            Authorization: `Bearer ${this._accessToken.access_token}`,
-            ...additionalHeaders
-        };
-
-        const url = `${this._gateway}${baseUrl}`;
-        log(`${message} Headers ${JSON.stringify(headers)} Url ${url}`);
-        try {
-            const request: any = { method: verb, headers: headers, agent: this._proxyHttpAgent };
-            if (verb !== "GET" && verb !== "DELETE") {
-                request.body = octetStream ? body : JSON.stringify(body);
-            }
-            const response = await fetch(url, request);
-
-            !response.ok && throwError(`${response.statusText} ${await response.text()}`);
-            (response.status < 200 || response.status > 299) &&
-                throwError(`invalid response ${JSON.stringify(response)}`);
-
-            if (noResponse) {
-                if (returnHeaders) {
-                    return response.headers;
-                }
-                return {};
-            }
-
-            const json = await response.json();
-            log(`${message} Response ${JSON.stringify(json)}`);
-            return json;
-        } catch (err) {
-            log(err);
-            throw new Error(`Network error occured ${err.message}`);
-        }
+    protected async GetToken() {
+        return await this.GetServiceToken();
+    }
+    protected GetGateway() {
+        return this._gateway;
     }
 }

--- a/src/api/sdk/iot/iot-timeseries.ts
+++ b/src/api/sdk/iot/iot-timeseries.ts
@@ -31,6 +31,8 @@ export class TimeSeriesClient extends SdkClient {
         const qs = toQueryString(optional);
         return (await this.HttpAction({
             verb: "GET",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/timeseries/${entity}/${propertysetname}?${qs}`,
             message: "GetTimeSeries"
         })) as TimeSeriesModels.Timeseries[];
@@ -50,6 +52,8 @@ export class TimeSeriesClient extends SdkClient {
         checkAssetId(entity);
         return await this.HttpAction({
             verb: "PUT",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/timeseries/${entity}/${propertysetname}`,
             body: timeseries,
             message: "PutTimeSeries",
@@ -74,6 +78,8 @@ export class TimeSeriesClient extends SdkClient {
         const qs = toQueryString({ from: from, to: to });
         return await this.HttpAction({
             verb: "DELETE",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/timeseries/${entity}/${propertysetname}?${qs}`,
             message: "DeleteTimeSeries",
             noResponse: true

--- a/src/api/sdk/iotbulk/iot-timeseries-bulk.ts
+++ b/src/api/sdk/iotbulk/iot-timeseries-bulk.ts
@@ -27,6 +27,8 @@ export class TimeSeriesBulkClient extends SdkClient {
     public async PostImportJob(job: TimeSeriesBulkModels.BulkImportInput): Promise<TimeSeriesBulkModels.JobStatus> {
         const result = (await this.HttpAction({
             verb: "POST",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/importJobs`,
             body: job,
             message: "PostImportJob"
@@ -47,6 +49,8 @@ export class TimeSeriesBulkClient extends SdkClient {
     public async GetJobStatus(jobId: string): Promise<TimeSeriesBulkModels.JobStatus> {
         const result = (await this.HttpAction({
             verb: "GET",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/importJobs/${jobId}`,
             message: "GetJobStatus"
         })) as any;
@@ -93,6 +97,8 @@ export class TimeSeriesBulkClient extends SdkClient {
         if (qs !== "") qs = `&${qs}`;
         return (await this.HttpAction({
             verb: "GET",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/timeseries/${entity}/${propertysetname}?${fromto}${qs}`,
             message: "GetTimeSeries"
         })) as TimeSeriesBulkModels.Timeseries[];

--- a/src/api/sdk/iotfile/iot-file.ts
+++ b/src/api/sdk/iotfile/iot-file.ts
@@ -12,6 +12,8 @@ export class IotFileClient extends SdkClient {
         checkAssetId(entityid);
         return (await (this.HttpAction({
             verb: "GET",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/files/${entityid}`,
             additionalHeaders: optional,
             message: "SearchFiles"
@@ -31,6 +33,8 @@ export class IotFileClient extends SdkClient {
 
         return (await this.HttpAction({
             verb: "PUT",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/files/${entityId}/${filepath}`,
             body: myBuffer,
             additionalHeaders: { ...optional },

--- a/src/api/sdk/iotfile/iot-file.ts
+++ b/src/api/sdk/iotfile/iot-file.ts
@@ -19,19 +19,19 @@ export class IotFileClient extends SdkClient {
     }
 
     public async PutFile(
-        entityid: string,
+        entityId: string,
         filepath: string,
         file: string | Buffer,
         optional?: { part?: number; "If-Match"?: number; timestamp?: Date; description?: string; type?: string }
     ): Promise<Headers> {
-        checkAssetId(entityid);
+        checkAssetId(entityId);
 
         const myBuffer = typeof file === "string" ? fs.readFileSync(file) : (file as Buffer);
         optional = optional || {};
 
         return (await this.HttpAction({
             verb: "PUT",
-            baseUrl: `${this._baseUrl}/files/${entityid}/${filepath}`,
+            baseUrl: `${this._baseUrl}/files/${entityId}/${filepath}`,
             body: myBuffer,
             additionalHeaders: { ...optional },
             octetStream: true,

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -191,11 +191,11 @@ export const retry = async (n: number, func: Function, timoutinMilliseconds: num
     throw error;
 };
 
-export const retrylog = function(operation: string) {
+export const retrylog = function(operation: string, c: Function = chalk.cyanBright) {
     let x = 0;
     return () => {
         if (x > 0) {
-            console.log(`Retry no ${chalk.cyanBright("" + x)} for ${chalk.cyanBright(operation)} operation.`);
+            console.log(`Retry no ${c("" + x)} for ${c(operation)} operation.`);
         }
         x++;
     };

--- a/src/cli/commands/mc-upload-file.ts
+++ b/src/cli/commands/mc-upload-file.ts
@@ -97,8 +97,7 @@ export default (program: CommanderStatic) => {
                     await agent.UploadFile(assetid, path.basename(uploadFile), uploadFile, {
                         description: description,
                         chunk: chunked,
-                        retry: options.retry,
-                        logFunction: retrylog("UploadFile")
+                        retry: options.retry
                     });
 
                     log(`Your file ${chalk.cyanBright(uploadFile)} was succesfully uploaded.`);

--- a/src/cli/commands/mc-upload-file.ts
+++ b/src/cli/commands/mc-upload-file.ts
@@ -94,12 +94,13 @@ export default (program: CommanderStatic) => {
                     );
                     verboseLog(chunked ? `Using chunked upload` : `No chunked upload`, options.verbose);
 
-                    await retry(
-                        options.retry,
-                        () => agent.Upload(uploadFile, mimeType, description, chunked, assetid),
-                        300,
-                        retrylog("FileUpload")
-                    );
+                    await agent.UploadFile(assetid, path.basename(uploadFile), uploadFile, {
+                        description: description,
+                        chunk: chunked,
+                        retry: options.retry,
+                        logFunction: retrylog("UploadFile")
+                    });
+
                     log(`Your file ${chalk.cyanBright(uploadFile)} was succesfully uploaded.`);
                 } catch (err) {
                     errorLog(err, options.verbose);

--- a/src/cli/commands/mc-upload-file.ts
+++ b/src/cli/commands/mc-upload-file.ts
@@ -94,12 +94,23 @@ export default (program: CommanderStatic) => {
                     );
                     verboseLog(chunked ? `Using chunked upload` : `No chunked upload`, options.verbose);
 
+                    const startDate = new Date();
+
                     await agent.UploadFile(assetid, path.basename(uploadFile), uploadFile, {
                         description: description,
                         chunk: chunked,
-                        retry: options.retry
+                        retry: options.retry,
+                        logFunction: (p: string) => {
+                            return retrylog(p, chalk.cyanBright);
+                        },
+                        verboseFunction: (p: string) => {
+                            verboseLog(p, options.verbose);
+                        }
                     });
 
+                    const endDate = new Date();
+
+                    log(`Upload time: ${(endDate.getTime() - startDate.getTime()) / 1000} seconds`);
                     log(`Your file ${chalk.cyanBright(uploadFile)} was succesfully uploaded.`);
                 } catch (err) {
                     errorLog(err, options.verbose);

--- a/src/demoagent/test-agent.ts
+++ b/src/demoagent/test-agent.ts
@@ -10,7 +10,7 @@ import { DataPointValue, MindConnectAgent, MindsphereStandardEvent, retry, TimeS
     };
     const RETRYTIMES = 5; // retry the operation before giving up and throwing exception
 
-    for (let index = 0; index < 1000000; index++) {
+    for (let index = 0; index < 5; index++) {
         try {
             log(`Iteration : ${index}`);
             // onboarding the agent
@@ -67,9 +67,14 @@ import { DataPointValue, MindConnectAgent, MindsphereStandardEvent, retry, TimeS
             log("event posted");
             await sleep(1000);
 
-            // upload file, as this can be multipart operation the UploadFile method does its' own retrying
+            // upload file
+            // the upload-file can be a multipart operation and therefore can be configured to
+            // retry the upload of the chunks instead the upload of the whole file.
+            // if you don't specify the type , the mimetype is automatically determined by the library
             await agent.UploadFile(agent.ClientId(), "custom/mindsphere/path/package.json", "package.json", {
-                retry: RETRYTIMES
+                retry: RETRYTIMES,
+                description: "File uploaded with MindConnect-NodeJS Library",
+                chunk: true // the chunk parameter activates multipart upload
             });
 
             log("file uploaded");

--- a/src/demoagent/test-agent.ts
+++ b/src/demoagent/test-agent.ts
@@ -1,17 +1,17 @@
 // Copyright (C), Siemens AG 2017
 import { DataPointValue, MindConnectAgent, MindsphereStandardEvent, retry, TimeStampedDataPoint } from "..";
 
-(async function () {
-
+(async function() {
     const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
     const configuration = require("../../agentconfig.json");
     const agent = new MindConnectAgent(configuration);
-    const log = (text: any) => { console.log(`[${new Date().toISOString()}] ${text.toString()}`); };
+    const log = (text: any) => {
+        console.log(`[${new Date().toISOString()}] ${text.toString()}`);
+    };
     const RETRYTIMES = 5; // retry the operation before giving up and throwing exception
 
     for (let index = 0; index < 1000000; index++) {
         try {
-
             log(`Iteration : ${index}`);
             // onboarding the agent
             if (!agent.IsOnBoarded()) {
@@ -27,13 +27,21 @@ import { DataPointValue, MindConnectAgent, MindsphereStandardEvent, retry, TimeS
             }
 
             const values: DataPointValue[] = [
-                { "dataPointId": "DP-Temperature", "qualityCode": "0", "value": (Math.sin(index) * (20 + index % 2) + 25).toString() },
-                { "dataPointId": "DP-Pressure", "qualityCode": "0", "value": (Math.cos(index) * (20 + index % 25) + 25).toString() },
-                { "dataPointId": "DP-Humidity", "qualityCode": "0", "value": ((index + 30) % 100).toString() },
-                { "dataPointId": "DP-Acceleration", "qualityCode": "0", "value": (1000.0 + index).toString() },
-                { "dataPointId": "DP-Frequency", "qualityCode": "0", "value": (60.0 + (index * 0.1)).toString() },
-                { "dataPointId": "DP-Displacement", "qualityCode": "0", "value": (index % 10).toString() },
-                { "dataPointId": "DP-Velocity", "qualityCode": "0", "value": (50.0 + index).toString() }
+                {
+                    dataPointId: "DP-Temperature",
+                    qualityCode: "0",
+                    value: (Math.sin(index) * (20 + (index % 2)) + 25).toString()
+                },
+                {
+                    dataPointId: "DP-Pressure",
+                    qualityCode: "0",
+                    value: (Math.cos(index) * (20 + (index % 25)) + 25).toString()
+                },
+                { dataPointId: "DP-Humidity", qualityCode: "0", value: ((index + 30) % 100).toString() },
+                { dataPointId: "DP-Acceleration", qualityCode: "0", value: (1000.0 + index).toString() },
+                { dataPointId: "DP-Frequency", qualityCode: "0", value: (60.0 + index * 0.1).toString() },
+                { dataPointId: "DP-Displacement", qualityCode: "0", value: (index % 10).toString() },
+                { dataPointId: "DP-Velocity", qualityCode: "0", value: (50.0 + index).toString() }
             ];
 
             // same like above, you can also just call  await agent.PostData(values) if you don't want to retry the operation
@@ -45,13 +53,13 @@ import { DataPointValue, MindConnectAgent, MindsphereStandardEvent, retry, TimeS
             await sleep(1000);
 
             const event: MindsphereStandardEvent = {
-                "entityId": agent.ClientId(), // use assetid if you want to send event somewhere else :)
-                "sourceType": "Event",
-                "sourceId": "application",
-                "source": "Meowz",
-                "severity": 20, // 0-99 : 20:error, 30:warning, 40: information
-                "timestamp": new Date().toISOString(),
-                "description": "Test"
+                entityId: agent.ClientId(), // use assetid if you want to send event somewhere else :)
+                sourceType: "Event",
+                sourceId: "application",
+                source: "Meowz",
+                severity: 20, // 0-99 : 20:error, 30:warning, 40: information
+                timestamp: new Date().toISOString(),
+                description: "Test"
             };
 
             // send event with current timestamp; you can also just call agent.PostEvent(event) if you don't want to retry the operation
@@ -59,30 +67,36 @@ import { DataPointValue, MindConnectAgent, MindsphereStandardEvent, retry, TimeS
             log("event posted");
             await sleep(1000);
 
-            // upload file;  you can also just call await agent.Upload(...) if you don't want to retry the operation
-            await retry(RETRYTIMES, () => agent.Upload("package.json", "application/json", "Demo File"));
+            // upload file, as this can be multipart operation the UploadFile method does its' own retrying
+            await agent.UploadFile(agent.ClientId(), "custom/mindsphere/path/package.json", "package.json", {
+                retry: RETRYTIMES
+            });
+
             log("file uploaded");
             await sleep(1000);
 
             const yesterday = new Date();
             yesterday.setDate(yesterday.getDate() - 1);
-            const bulk: TimeStampedDataPoint[] =
-                [{
-                    "timestamp": yesterday.toISOString(),
-                    "values":
-                        [{ "dataPointId": "DP-Temperature", "qualityCode": "0", "value": "10" },
-                        { "dataPointId": "DP-Pressure", "qualityCode": "0", "value": "10" }]
+            const bulk: TimeStampedDataPoint[] = [
+                {
+                    timestamp: yesterday.toISOString(),
+                    values: [
+                        { dataPointId: "DP-Temperature", qualityCode: "0", value: "10" },
+                        { dataPointId: "DP-Pressure", qualityCode: "0", value: "10" }
+                    ]
                 },
                 {
-                    "timestamp": new Date().toISOString(),
-                    "values": [{ "dataPointId": "DP-Temperature", "qualityCode": "0", "value": "10" },
-                    { "dataPointId": "DP-Pressure", "qualityCode": "0", "value": "10" }]
-                }];
+                    timestamp: new Date().toISOString(),
+                    values: [
+                        { dataPointId: "DP-Temperature", qualityCode: "0", value: "10" },
+                        { dataPointId: "DP-Pressure", qualityCode: "0", value: "10" }
+                    ]
+                }
+            ];
 
             await retry(RETRYTIMES, () => agent.BulkPostData(bulk));
             log("bulk data uploaded");
             await sleep(1000);
-
         } catch (err) {
             // add proper error handling (e.g. store data somewhere, retry later etc. )
             console.error(err);

--- a/templates/js/js-template.ts
+++ b/templates/js/js-template.ts
@@ -59,6 +59,17 @@ export const jstemplate: string = `const { MindConnectAgent, retry } = require (
             log("event posted");
             await sleep(1000);
 
+
+            // upload file
+            // the upload-file can be a multipart operation and therefore can be configured to
+            // retry the upload of the chunks instead the upload of the whole file.
+            // if you don't specify the type , the mimetype is automatically determined by the library
+            await agent.UploadFile(agent.ClientId(), "custom/mindsphere/path/package.json", "package.json", {
+                retry: RETRYTIMES,
+                description: "File uploaded with MindConnect-NodeJS Library",
+                chunk: true // the chunk parameter activates multipart upload
+            });
+
             // upload file;  you can also just call await agent.Upload(...) if you don't want to retry the operation
             await retry(RETRYTIMES, () => agent.Upload("package.json", "application/json", "Demo File"));
             log("file uploaded");

--- a/templates/ts/ts-template.ts
+++ b/templates/ts/ts-template.ts
@@ -59,10 +59,15 @@ export const tstemplate: string = `import { DataPointValue, MindConnectAgent, Mi
             log("event posted");
             await sleep(1000);
 
-            // upload file;  you can also just call await agent.Upload(...) if you don't want to retry the operation
-            await retry(RETRYTIMES, () => agent.Upload("package.json", "application/json", "Demo File"));
-            log("file uploaded");
-            await sleep(1000);
+            // upload file
+            // the upload-file can be a multipart operation and therefore can be configured to
+            // retry the upload of the chunks instead the upload of the whole file.
+            // if you don't specify the type , the mimetype is automatically determined by the library
+            await agent.UploadFile(agent.ClientId(), "custom/mindsphere/path/package.json", "package.json", {
+                retry: RETRYTIMES,
+                description: "File uploaded with MindConnect-NodeJS Library",
+                chunk: true // the chunk parameter activates multipart upload
+            });
 
             const yesterday = new Date();
             yesterday.setDate(yesterday.getDate() - 1);
@@ -90,18 +95,14 @@ export const tstemplate: string = `import { DataPointValue, MindConnectAgent, Mi
     }
 })();`;
 
-
 export const tsconfigjson = {
-    "compilerOptions": {
-        "target": "es2015",
-        "module": "commonjs",
-        "lib": [
-            "es2015",
-            "dom"
-        ],
-        "allowJs": false,
-        "declaration": true,
-        "sourceMap": true,
-        "strict": true
+    compilerOptions: {
+        target: "es2015",
+        module: "commonjs",
+        lib: ["es2015", "dom"],
+        allowJs: false,
+        declaration: true,
+        sourceMap: true,
+        strict: true
     }
 };

--- a/test/mindconnect-agent-3.spec.ts
+++ b/test/mindconnect-agent-3.spec.ts
@@ -1,6 +1,8 @@
 // Copyright (C), Siemens AG 2017
 import * as chai from "chai";
 import * as debug from "debug";
+import * as fs from "fs";
+import { it } from "mocha";
 import * as os from "os";
 import "url-search-params-polyfill";
 import {
@@ -657,6 +659,39 @@ describe("MindConnectApi Version 3 Agent (SHARED_SECRET)", () => {
             });
 
             logCount.should.be.gte(3);
+        })
+    );
+
+    it(
+        "should be able to upload files",
+        mochaAsync(async () => {
+            const agent = new MindConnectAgent(sharedSecretConfig);
+            if (!agent.IsOnBoarded()) {
+                await agent.OnBoard();
+            }
+
+            const date = new Date().getTime();
+            const result1 = await agent.UploadFile(agent.ClientId(), `x/test/package-lock.json`, "package-lock.json");
+
+            const result2 = await agent.UploadFile(
+                agent.ClientId(),
+                `x/test/buffer-package-lock.json`,
+                fs.readFileSync("package-lock.json"),
+                { chunkSize: 5 * 1024 * 1024, type: "application/json" }
+            );
+
+            const result3 = await agent.Upload(
+                "package-lock.json",
+                "application/json",
+                "",
+                false,
+                undefined,
+                undefined,
+                undefined,
+                `x/test/upload-package-lock.json`
+            );
+            result1.should.be.equal(result2);
+            result1.should.be.equal(result3);
         })
     );
 });

--- a/test/mindconnect-agent-3.spec.ts
+++ b/test/mindconnect-agent-3.spec.ts
@@ -650,7 +650,7 @@ describe("MindConnectApi Version 3 Agent (SHARED_SECRET)", () => {
         })
     );
 
-    it.only(
+    it(
         "should be able to upload a file in 3 different ways",
         mochaAsync(async () => {
             const agent = new MindConnectAgent(sharedSecretConfig);
@@ -678,22 +678,80 @@ describe("MindConnectApi Version 3 Agent (SHARED_SECRET)", () => {
         })
     );
 
-    it.only(
-        "should be able to upload a big file",
+    it(
+        "should be able to upload a 16.25 mb big file [CI ONLY]",
+        mochaAsync(async () => {
+            if (!process.env.CI) {
+                return;
+            }
+
+            const agent = new MindConnectAgent(sharedSecretConfig);
+            if (!agent.IsOnBoarded()) {
+                await agent.OnBoard();
+            }
+
+            const checksum = await agent.UploadFile(
+                agent.ClientId(),
+                `test/16_25_mb_file.bin`,
+                Buffer.alloc(16.25 * 1024 * 1024),
+                { chunk: true }
+            );
+
+            checksum.should.be.equal("84c8648b8aa9b803ff92515a63aa4580");
+        })
+    );
+
+    it(
+        "should be able to upload 8 MB and 1 byte big file [CI ONLY]",
+        mochaAsync(async () => {
+            if (!process.env.CI) {
+                return;
+            }
+            const agent = new MindConnectAgent(sharedSecretConfig);
+            if (!agent.IsOnBoarded()) {
+                await agent.OnBoard();
+            }
+
+            const checksum = await agent.UploadFile(
+                agent.ClientId(),
+                `test/8mb_1byte_file.bin`,
+                Buffer.alloc(8 * 1024 * 1024 + 1),
+                { chunk: true }
+            );
+
+            checksum.should.be.equal("cba5242e77abe5709a262350cf64d835");
+        })
+    );
+
+    it(
+        "should be able to upload 1 byte big file",
         mochaAsync(async () => {
             const agent = new MindConnectAgent(sharedSecretConfig);
             if (!agent.IsOnBoarded()) {
                 await agent.OnBoard();
             }
 
-            const bigfile = await agent.UploadFile(
-                agent.ClientId(),
-                `test/36_25_mb_file.bin`,
-                Buffer.alloc(36.25 * 1024 * 1024),
-                { chunk: true }
-            );
+            const checksum = await agent.UploadFile(agent.ClientId(), `test/1_byte.bin`, Buffer.alloc(1), {
+                chunk: true
+            });
 
-            console.log(bigfile);
+            checksum.should.be.equal("93b885adfe0da089cdf634904fd59f71");
+        })
+    );
+
+    it(
+        "should be able to upload 0 byte big file",
+        mochaAsync(async () => {
+            const agent = new MindConnectAgent(sharedSecretConfig);
+            if (!agent.IsOnBoarded()) {
+                await agent.OnBoard();
+            }
+
+            const checksum = await agent.UploadFile(agent.ClientId(), `test/0_byte.bin`, Buffer.alloc(0), {
+                chunk: true
+            });
+
+            checksum.should.be.equal("d41d8cd98f00b204e9800998ecf8427e");
         })
     );
 });

--- a/test/mindconnect-agent-3.spec.ts
+++ b/test/mindconnect-agent-3.spec.ts
@@ -1,7 +1,6 @@
 // Copyright (C), Siemens AG 2017
 import * as chai from "chai";
 import * as debug from "debug";
-import * as fs from "fs";
 import { it } from "mocha";
 import * as os from "os";
 import "url-search-params-polyfill";
@@ -662,36 +661,37 @@ describe("MindConnectApi Version 3 Agent (SHARED_SECRET)", () => {
         })
     );
 
-    it(
+    it.only(
         "should be able to upload files",
         mochaAsync(async () => {
             const agent = new MindConnectAgent(sharedSecretConfig);
             if (!agent.IsOnBoarded()) {
                 await agent.OnBoard();
             }
+            const result1 = await agent.UploadFile(agent.ClientId(), `test14/package-lock.json`, "package-lock.json");
 
-            const date = new Date().getTime();
-            const result1 = await agent.UploadFile(agent.ClientId(), `x/test/package-lock.json`, "package-lock.json");
+            const buffer = new Buffer(24 * 1024 * 1024);
 
-            const result2 = await agent.UploadFile(
-                agent.ClientId(),
-                `x/test/buffer-package-lock.json`,
-                fs.readFileSync("package-lock.json"),
-                { chunkSize: 5 * 1024 * 1024, type: "application/json" }
-            );
+            const result2 = await agent.UploadFile(agent.ClientId(), `test/no-etags.bin`, buffer, {
+                chunkSize: 8 * 1024 * 1024,
+                type: "application/octet-stream",
+                chunk: true
+            });
 
-            const result3 = await agent.Upload(
-                "package-lock.json",
-                "application/json",
-                "",
-                false,
-                undefined,
-                undefined,
-                undefined,
-                `x/test/upload-package-lock.json`
-            );
-            result1.should.be.equal(result2);
-            result1.should.be.equal(result3);
+            console.log("4567");
+
+            // const result3 = await agent.Upload(
+            //     "package-lock.json",
+            //     "application/json",
+            //     "",
+            //     false,
+            //     undefined,
+            //     undefined,
+            //     undefined,
+            //     `x/test/upload-package-lock.json`
+            // );
+            // result1.should.be.equal(result2);
+            // result1.should.be.equal(result3);
         })
     );
 });

--- a/test/mindconnect-agent-performance-test.spec.ts
+++ b/test/mindconnect-agent-performance-test.spec.ts
@@ -1,16 +1,12 @@
 // Copyright (C), Siemens AG 2017
 import * as chai from "chai";
-import * as debug from "debug";
 import * as fs from "fs";
 import "url-search-params-polyfill";
 import { DataPointValue, IMindConnectConfiguration, MindConnectAgent, retry } from "../src";
 import { mochaAsync } from "./test-utils";
-const log = debug("mindconnect-agent-test");
-const HttpsProxyAgent = require("https-proxy-agent");
 chai.should();
 
 describe("MindConnectApi RSA_3072 Agent performance test", () => {
-
     const rsaConfig: IMindConnectConfiguration = require("../agentconfig.rsa.json");
 
     it("should instantiate RSA_3072 agent.", () => {
@@ -21,58 +17,67 @@ describe("MindConnectApi RSA_3072 Agent performance test", () => {
         (<any>agent)._storage.should.not.be.null;
     });
 
-    it("should function under heavy load", mochaAsync(async () => {
+    it(
+        "should function under heavy load",
+        mochaAsync(async () => {
+            if (!process.env.CI) {
+                return true; // run only during CI
+            }
 
-        const agent = new MindConnectAgent(rsaConfig);
-        agent.SetupAgentCertificate(fs.readFileSync("private.key"));
-        if (!agent.IsOnBoarded()) {
-            await agent.OnBoard();
-        }
+            const agent = new MindConnectAgent(rsaConfig);
+            agent.SetupAgentCertificate(fs.readFileSync("private.key"));
+            if (!agent.IsOnBoarded()) {
+                await agent.OnBoard();
+            }
 
-        if (!agent.HasDataSourceConfiguration()) {
-            await retry(5, () => agent.GetDataSourceConfiguration());
-        }
+            if (!agent.HasDataSourceConfiguration()) {
+                await retry(5, () => agent.GetDataSourceConfiguration());
+            }
 
-        const promises = [];
+            const promises = [];
 
-        for (let index = 0; index < 10; index++) {
-
-            const now = Math.floor(Date.now() / 1000);
-            (<any>agent)._configuration.response.client_secret_expires_at = now;
-            promises.push(await agent.RenewToken());
-        }
-
-        await Promise.all(promises);
-
-
-        for (let index = 0; index < 100; index++) {
-            const values: DataPointValue[] = [
-                { "dataPointId": "DP-Temperature", "qualityCode": "0", "value": (Math.sin(index) * (20 + index % 2) + 25).toString() },
-                { "dataPointId": "DP-Pressure", "qualityCode": "0", "value": (Math.cos(index) * (20 + index % 25) + 25).toString() },
-                { "dataPointId": "DP-Humidity", "qualityCode": "0", "value": ((index + 30) % 100).toString() },
-                { "dataPointId": "DP-Acceleration", "qualityCode": "0", "value": (1000.0 + index).toString() },
-                { "dataPointId": "DP-Frequency", "qualityCode": "0", "value": (60.0 + (index * 0.1)).toString() },
-                { "dataPointId": "DP-Displacement", "qualityCode": "0", "value": (index % 10).toString() },
-                { "dataPointId": "DP-Velocity", "qualityCode": "0", "value": (50.0 + index).toString() }
-            ];
-
-            if (Date.now() % 3 === 0) {
+            for (let index = 0; index < 10; index++) {
                 const now = Math.floor(Date.now() / 1000);
                 (<any>agent)._configuration.response.client_secret_expires_at = now;
+                promises.push(await agent.RenewToken());
             }
 
-            const validator = agent.GetValidator();
-            const isValid = await validator(values);
-            if (isValid) {
-                const result = await retry(5, () => agent.PostData(values));
-            } else {
-                throw new Error("invalid configuration!");
+            await Promise.all(promises);
+
+            for (let index = 0; index < 100; index++) {
+                const values: DataPointValue[] = [
+                    {
+                        dataPointId: "DP-Temperature",
+                        qualityCode: "0",
+                        value: (Math.sin(index) * (20 + (index % 2)) + 25).toString()
+                    },
+                    {
+                        dataPointId: "DP-Pressure",
+                        qualityCode: "0",
+                        value: (Math.cos(index) * (20 + (index % 25)) + 25).toString()
+                    },
+                    { dataPointId: "DP-Humidity", qualityCode: "0", value: ((index + 30) % 100).toString() },
+                    { dataPointId: "DP-Acceleration", qualityCode: "0", value: (1000.0 + index).toString() },
+                    { dataPointId: "DP-Frequency", qualityCode: "0", value: (60.0 + index * 0.1).toString() },
+                    { dataPointId: "DP-Displacement", qualityCode: "0", value: (index % 10).toString() },
+                    { dataPointId: "DP-Velocity", qualityCode: "0", value: (50.0 + index).toString() }
+                ];
+
+                if (Date.now() % 3 === 0) {
+                    const now = Math.floor(Date.now() / 1000);
+                    (<any>agent)._configuration.response.client_secret_expires_at = now;
+                }
+
+                const validator = agent.GetValidator();
+                const isValid = await validator(values);
+                if (isValid) {
+                } else {
+                    throw new Error("invalid configuration!");
+                }
+
+                await retry(3, () => agent.Upload("images/mappings.png", "", "desc"));
+                await retry(3, () => agent.Upload("images/mc4.png", "", "desc"));
             }
-
-            await retry(3, () => agent.Upload("images/mappings.png", "", "desc"));
-            await retry(3, () => agent.Upload("images/mc4.png", "", "desc", true, undefined, 1024));
-        }
-
-    }));
-
+        })
+    );
 });

--- a/test/mindconnect-agent-performance-test.spec.ts
+++ b/test/mindconnect-agent-performance-test.spec.ts
@@ -21,7 +21,7 @@ describe("MindConnectApi RSA_3072 Agent performance test", () => {
         "should function under heavy load",
         mochaAsync(async () => {
             if (!process.env.CI) {
-                return true; // run only during CI
+                return; // run only during CI
             }
 
             const agent = new MindConnectAgent(rsaConfig);


### PR DESCRIPTION
- mindconnect-agent: created new UploadFile method capable of running the multipart upload (#4)
- mindconnect-agent: the UploadFile can now take a buffer additionally to file (#23)
- mindconnect-agent: the MindSphere path name can be configured (#23)
- mindconnect-agent: deprecated  (#23)
- SDK: started a SDK for the new commands which require additional mindsphere APIs 
- SDK: the SDK will be extracted to a separate package in the version major version (4.0.0)
- CLI: the CLI will be extracted to a separate package in the future major version (4.0.0)