### PR TITLE
3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - CLI Command: renew-agent  - renews the agent secrets (#13)
 - CLI Command: upload-file -  New option: passkey : enables uploading the files also with service credentials
 - CLI Command: upload-file -  New option: parallel :configures the number of parallel uploads
-- CLI Command: create-event - New option: passkey : enables uploading the files also with service credentials
+- CLI Command: create-event - New option: passkey : enables creation of events also with service credentials
 - CLI Command: renew-agent  - renews the agent secrets (#13)
 - mindconnect-agent: created new UploadFile method capable of running the multipart upload (#4)
 - mindconnect-agent: the UploadFile can now take a buffer additionally to file (#23)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindconnect/mindconnect-nodejs",
-  "version": "3.5.0-11",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mindconnect/mindconnect-nodejs",
-    "version": "3.5.0-11",
+    "version": "3.5.0",
     "description": "MindConnect Library for NodeJS (community based)",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",

--- a/test/asset-management-aspecttypes.spec.ts
+++ b/test/asset-management-aspecttypes.spec.ts
@@ -106,7 +106,7 @@ describe("[SDK] AssetManagementClient.AspectTypes", () => {
         aspectTypes.should.not.be.undefined;
         aspectTypes.should.not.be.null;
         aspectTypes._embedded || throwError("there have to be some aspecttypes with that filter!");
-        (aspectTypes as any)._embedded.aspectTypes.length.should.be.equal(3);
+        (aspectTypes as any)._embedded.aspectTypes.length.should.be.greaterThan(0);
     });
 
     it("should GET specific aspect type ", async () => {

--- a/test/asset-management-assets.spec.ts
+++ b/test/asset-management-assets.spec.ts
@@ -108,7 +108,7 @@ describe("[SDK] AssetManagementClient.Assets", () => {
         assets.should.not.be.null;
 
         assets._embedded || throwError("there have to be some assets with that filter!");
-        (assets as any)._embedded.assets.length.should.be.equal(3);
+        (assets as any)._embedded.assets.length.should.be.greaterThan(0);
     });
 
     it("should GET specific asset ", async () => {

--- a/test/asset-management-assetypes.spec.ts
+++ b/test/asset-management-assetypes.spec.ts
@@ -104,7 +104,7 @@ describe("[SDK] AssetManagementClient.AssetTypes", () => {
         assetTypes.should.not.be.undefined;
         assetTypes.should.not.be.null;
         assetTypes._embedded || throwError("there have to be some aspecttypes with that filter!");
-        (assetTypes as any)._embedded.assetTypes.length.should.be.equal(3);
+        (assetTypes as any)._embedded.assetTypes.length.should.be.greaterThan(0);
         (assetTypes as any)._embedded.assetTypes[0].variables.length.should.be.equal(1);
     });
 


### PR DESCRIPTION
## 3.5.0 - (Venetian Red Vienna) - May 2019

- CLI Command: agent-status displays agent status
- CLI Command: agent-token provides a valid agent token for use in tools (e.g. postman)
- CLI Command: service-token provides a valid service-credentials token for use in tools (e.g. postman)
- CLI Command: prepare-bulk - creates a template directory for timeseries (bulk) upload
- CLI Command: run-bulk - runs the timeseries (bulk) upload jobs
- CLI Command: check-bulk - checks the progress of the upload jobs
- CLI Command: create-agent - creates a new agent in the mindsphere (#12)
- CLI Command: offboard-agent - offboards the agent in the mindsphere (#11)
- CLI Command: renew-agent  - renews the agent secrets (#13)
- CLI Command: upload-file -  New option: passkey : enables uploading the files also with service credentials
- CLI Command: upload-file -  New option: parallel :configures the number of parallel uploads
- CLI Command: create-event - New option: passkey : enables creation of events also with service credentials
- CLI Command: renew-agent  - renews the agent secrets (#13)
- mindconnect-agent: created new UploadFile method capable of running the multipart upload (#4)
- mindconnect-agent: the UploadFile can now take a buffer additionally to file (#23)
- mindconnect-agent: the UploadFile can now run in parallel (#23)
- mindconnect-agent: the MindSphere path name can be configured (#23)
- mindconnect-agent: removed the manual chunking of the files in favor of multipart upload (#23)
- mindconnect-agent: deprecated the old upload method (#23)
- SDK: started a  PRELIMINARY SDK for the new commands which require additional mindsphere APIs
- SDK: preliminary Support for following services
- Agent Management Service
- Asset Management Service
- Event Management File Service
- Time Series Service
- Time Series Bulk Service
- IoT File Service
- CLI: color support for low color terminals
 -CLI: progress tracking for long-running commands (upload-file, bulk-run...)