### PR TITLE
chore(release): recovery release for node 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 3.6.0 - (Cosmic Cobalt Vienna)
+## 3.5.3 - (Venetian Red Vienna) - May 2019 - Recovery
+
+## Bugfix 3.5.3
+
+- added node v8 compatible URL import for Raspberry PIs
 
 ## 3.5.2 - (Venetian Red Vienna) - May 2019 - Recovery
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindconnect/mindconnect-nodejs",
-  "version": "3.6.0-1",
+  "version": "3.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mindconnect/mindconnect-nodejs",
-    "version": "3.6.0-1",
+    "version": "3.5.3",
     "description": "MindConnect Library for NodeJS (community based)",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",

--- a/src/api/mindconnect-base.ts
+++ b/src/api/mindconnect-base.ts
@@ -41,7 +41,7 @@ export abstract class MindConnectBase {
     protected _headers = {
         Accept: "*/*",
         "X-Powered-By": "meowz",
-        "User-Agent": "mindconnect-nodejs (3.6.0)"
+        "User-Agent": "mindconnect-nodejs (3.5.3)"
     };
 
     /**

--- a/src/api/sdk/common/multipart-uploader.ts
+++ b/src/api/sdk/common/multipart-uploader.ts
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as http from "http";
 import * as path from "path";
 import * as stream from "stream";
+import { URL } from "url";
 import { MindConnectAgent } from "../../..";
 import { MindConnectBase } from "../../mindconnect-base";
 import { retry, throwError } from "../../utils";

--- a/src/cli/commands/mc-version-help.ts
+++ b/src/cli/commands/mc-version-help.ts
@@ -8,7 +8,7 @@ const green = getColor("green");
 const red = getColor("red");
 
 export default (program: CommanderStatic) => {
-    program.version("MindConnect NodeJS CLI - Version: 3.6.0");
+    program.version("MindConnect NodeJS CLI - Version: 3.5.3");
 
     program.on("--help", () => {
         log(`\n  Documentation:\n`);


### PR DESCRIPTION
# Changelog

## 3.5.3 - (Venetian Red Vienna) - May 2019 - Recovery

## Bugfix 3.5.3

- added node v8 compatible URL import for Raspberry PIs

Closes #50 