### PR TITLE
feat: add support for direct interaction with TimeSeries Data to TrendPrediction Client 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Improvements 3.10.0
 
+- SDK: feat: add support for direct interaction to TrendPrediction Client (#204) [#hacktoberfest, coding4funrocks]
+- SDK: added support for direct interaction to KPI Calculation Client (#203) [#hacktoberfest, coding4funrocks]
 - SDK: fixed bug in EventManagementSDK GetEventTypes method (superflous history parameter)
 - unit tests: changed passkey for unit tests to work with passkey set up in environment (#207)
 - unit tests: added @sanity and @s4f (start for free) unit test suites (#208)

--- a/src/api/sdk/trend/trend-prediction-models.ts
+++ b/src/api/sdk/trend/trend-prediction-models.ts
@@ -20,6 +20,52 @@ export namespace TrendPredictionModels {
     }
 
     /**
+     * All the information needed to identify a variable.
+     * @export
+     * @interface BasicVariableDefinitionDirect
+     */
+    export interface BasicVariableDefinitionDirect {
+        /**
+         *
+         * @type {string}
+         * @memberof BasicVariableDefinitionDirect
+         */
+        assetId: string;
+        /**
+         *
+         * @type {string}
+         * @memberof BasicVariableDefinitionDirect
+         */
+        aspectName: string;
+    }
+
+    /**
+     * All the information needed to identify a variable.
+     * @export
+     * @interface BasicVariableDefinitionPredictDirect
+     */
+    export interface BasicVariableDefinitionPredictDirect {
+        /**
+         *
+         * @type {string}
+         * @memberof BasicVariableDefinitionPredictDirect
+         */
+        assetId: string;
+        /**
+         *
+         * @type {string}
+         * @memberof BasicVariableDefinitionPredictDirect
+         */
+        aspectName: string;
+        /**
+         *
+         * @type {string}
+         * @memberof BasicVariableDefinitionPredictDirect
+         */
+        variableNames?: string;
+    }
+
+    /**
      *
      * @export
      * @interface Link
@@ -84,6 +130,44 @@ export namespace TrendPredictionModels {
     }
 
     /**
+     * A trained regression model.
+     * @export
+     * @interface ModelDtoDirect
+     */
+    export interface ModelDtoDirect {
+        /**
+         *
+         * @type {string}
+         * @memberof ModelDtoDirect
+         */
+        id?: string;
+        /**
+         *
+         * @type {MultivarParamsDirect}
+         * @memberof ModelDtoDirect
+         */
+        metadataConfiguration?: MultivarParamsDirect;
+        /**
+         *
+         * @type {number}
+         * @memberof ModelDtoDirect
+         */
+        intercept?: number;
+        /**
+         *
+         * @type {Array<number>}
+         * @memberof ModelDtoDirect
+         */
+        coefficients?: Array<number>;
+        /**
+         *
+         * @type {string}
+         * @memberof ModelDtoDirect
+         */
+        creationDate?: string;
+    }
+
+    /**
      * All the information needed to identify both the input and output variables.
      * @export
      * @interface MultivarParams
@@ -104,6 +188,26 @@ export namespace TrendPredictionModels {
     }
 
     /**
+     * All the information needed to identify both the input and output variables.
+     * @export
+     * @interface MultivarParamsDirect
+     */
+    export interface MultivarParamsDirect {
+        /**
+         *
+         * @type {VariableDefinitionDirect}
+         * @memberof MultivarParamsDirect
+         */
+        outputVariable?: VariableDefinitionDirect;
+        /**
+         *
+         * @type {Array<VariableDefinitionDirect>}
+         * @memberof MultivarParamsDirect
+         */
+        inputVariables?: Array<VariableDefinitionDirect>;
+    }
+
+    /**
      * Data structure containing all information required for predicting future values of a given output variable using a pre-trained regression model.
      * @export
      * @interface PredictBody
@@ -121,6 +225,26 @@ export namespace TrendPredictionModels {
          * @memberof PredictBody
          */
         predictionData?: Array<VariableToTimeseries>;
+    }
+
+    /**
+     * Data structure containing all information required for predicting future values of a given output variable using a pre-trained regression model.
+     * @export
+     * @interface PredictBodyDirect
+     */
+    export interface PredictBodyDirect {
+        /**
+         *
+         * @type {PredictBodyModelConfiguration}
+         * @memberof PredictBodyDirect
+         */
+        modelConfiguration?: PredictBodyModelConfiguration;
+        /**
+         *
+         * @type {Array<VariableToTimeseriesDirect>}
+         * @memberof PredictBodyDirect
+         */
+        predictionData?: Array<VariableToTimeseriesDirect>;
     }
 
     /**
@@ -145,19 +269,20 @@ export namespace TrendPredictionModels {
     export interface PredictionDataArray extends Array<VariableToTimeseries> {}
 
     /**
+     * An array containing the predicted values of a given output variable.
+     * @export
+     * @interface PredictionDataArrayDirect
+     */
+    export interface PredictionDataArrayDirect extends Array<VariableToTimeseriesResponseDirect> {}
+
+    /**
      *
      * @export
      * @interface Timeseries
      */
     export interface Timeseries {
-        [key: string]: number | any;
+        [key: string]: any | any;
 
-        /**
-         * string
-         * @type {any}
-         * @memberof Timeseries
-         */
-        string?: any;
         /**
          * time
          * @type {string}
@@ -190,6 +315,26 @@ export namespace TrendPredictionModels {
          * @memberof TrainBody
          */
         trainingData?: Array<VariableToTimeseries>;
+    }
+
+    /**
+     * Data structure containing all information required for training a regression model.
+     * @export
+     * @interface TrainBodyDirect
+     */
+    export interface TrainBodyDirect {
+        /**
+         *
+         * @type {TrainBodyModelConfiguration}
+         * @memberof TrainBodyDirect
+         */
+        modelConfiguration?: TrainBodyModelConfiguration;
+        /**
+         *
+         * @type {MultivarParamsDirect}
+         * @memberof TrainBodyDirect
+         */
+        metadataConfiguration?: MultivarParamsDirect;
     }
 
     /**
@@ -239,6 +384,26 @@ export namespace TrendPredictionModels {
     }
 
     /**
+     * Data structure containing all information required for training a regression model and predicting future values of a given output variable.
+     * @export
+     * @interface TrainPredictBodyDirect
+     */
+    export interface TrainPredictBodyDirect {
+        /**
+         *
+         * @type {TrainBodyModelConfiguration}
+         * @memberof TrainPredictBodyDirect
+         */
+        modelConfiguration?: TrainBodyModelConfiguration;
+        /**
+         *
+         * @type {MultivarParamsDirect}
+         * @memberof TrainPredictBodyDirect
+         */
+        metadataConfiguration?: MultivarParamsDirect;
+    }
+
+    /**
      * All the information needed to identify a variable.
      * @export
      * @interface VariableDefinition
@@ -250,6 +415,20 @@ export namespace TrendPredictionModels {
          * @memberof VariableDefinition
          */
         propertyName?: string;
+    }
+
+    /**
+     * All the information needed to identify a variable.
+     * @export
+     * @interface VariableDefinitionDirect
+     */
+    export interface VariableDefinitionDirect extends BasicVariableDefinitionDirect {
+        /**
+         *
+         * @type {string}
+         * @memberof VariableDefinitionDirect
+         */
+        variableName?: string;
     }
 
     /**
@@ -268,6 +447,40 @@ export namespace TrendPredictionModels {
          *
          * @type {Array<Timeseries>}
          * @memberof VariableToTimeseries
+         */
+        timeSeries?: Array<Timeseries>;
+    }
+
+    /**
+     * Data structure which allows to map the time series values to a given variable.
+     * @export
+     * @interface VariableToTimeseriesDirect
+     */
+    export interface VariableToTimeseriesDirect {
+        /**
+         *
+         * @type {BasicVariableDefinitionPredictDirect}
+         * @memberof VariableToTimeseriesDirect
+         */
+        variable?: BasicVariableDefinitionPredictDirect;
+    }
+
+    /**
+     * Data structure which allows to map the time series values to a given variable.
+     * @export
+     * @interface VariableToTimeseriesResponseDirect
+     */
+    export interface VariableToTimeseriesResponseDirect {
+        /**
+         *
+         * @type {BasicVariableDefinitionDirect}
+         * @memberof VariableToTimeseriesResponseDirect
+         */
+        variable?: BasicVariableDefinitionDirect;
+        /**
+         *
+         * @type {Array<Timeseries>}
+         * @memberof VariableToTimeseriesResponseDirect
          */
         timeSeries?: Array<Timeseries>;
     }

--- a/src/api/sdk/trend/trend-prediction.ts
+++ b/src/api/sdk/trend/trend-prediction.ts
@@ -42,9 +42,52 @@ export class TrendPredictionClient extends SdkClient {
             gateway: this.GetGateway(),
             authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/train`,
-            body: modelData
+            body: modelData,
         });
         return result as TrendPredictionModels.ModelDto;
+    }
+
+    /**
+     * Fits a regression model on the training dataset, storing the trained regression model in a database.
+     *
+     * @param {TrendPredictionModels.TrainBodyDirect} modelData
+     * @param {{
+     *             from: Date;
+     *             to: Date;
+     *         }} params
+     * @param params.from Beginning of the time range to be retrieved (exclusive)
+     * @param params.to End of the time range to be retrieved (exclusive)
+     *
+     * * Data structure with two parts - modelConfiguration, metadataConfiguration.
+     *
+     * * modelConfiguration
+     * contains the information necessary for configuring the regression model to
+     * be trained (e.g., the degree of a polynomial in case of polynomial regression).
+     *
+     * * metadataConfiguration
+     * specifies which variables are the input variables (regressors), and which one is the output variable
+     * (regressand) of the regression model. In order to specify time as one of the input variables,
+     * set propertyName equal to timestamp.
+     *
+     * @returns {Promise<TrendPredictionModels.ModelDtoDirect>}
+     *
+     * @memberOf TrendPredictionClient
+     */
+    public async TrainDirect(
+        modelData: TrendPredictionModels.TrainBodyDirect,
+        params: {
+            from: Date;
+            to: Date;
+        }
+    ): Promise<TrendPredictionModels.ModelDtoDirect> {
+        const result = await this.HttpAction({
+            verb: "POST",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
+            baseUrl: `${this._baseUrl}/trainDirect?${toQueryString(params)}`,
+            body: modelData,
+        });
+        return result as TrendPredictionModels.ModelDtoDirect;
     }
 
     /**
@@ -76,9 +119,55 @@ export class TrendPredictionClient extends SdkClient {
             gateway: this.GetGateway(),
             authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/predict`,
-            body: modelData
+            body: modelData,
         });
         return result as TrendPredictionModels.PredictionDataArray;
+    }
+
+    /**
+     * Predicts future values of a given output variable using a pre-trained regression model.
+     *
+     * @param {TrendPredictionModels.PredictBodyDirect} modelData
+     * @param {{
+     *             from: Date;
+     *             to: Date;
+     *         }} params
+     * @param params.from Beginning of the time range to be retrieved (exclusive)
+     * @param params.to End of the time range to be retrieved (exclusive)
+     *
+     * * Data structure with two parts - modelConfiguration and predictionData.
+     *
+     *  * modelConfiguration
+     * contains the information necessary to identify the pre-trained regression model (i.e., modelId).
+     *
+     *  * predictionData
+     * contains the values of the input variables used by the pre-trained regression model.
+     * Note that it is necessary to include the values for all of the input variables specified under
+     * metadataConfiguration at the training step.
+     *
+     * @example below assumes the two input variables that were used to train the regression model are
+     * [assetId: turbine1, aspectName: combustionSubpart1, variableName: pressure],
+     * [assetId: turbine1, aspectName: combustionSubpart1, variableName: temperature].
+     *
+     * @returns {Promise<TrendPredictionModels.PredictionDataArrayDirect>}
+     *
+     * @memberOf TrendPredictionClient
+     */
+    public async PredictDirect(
+        modelData: TrendPredictionModels.PredictBodyDirect,
+        params: {
+            from: Date;
+            to: Date;
+        }
+    ): Promise<TrendPredictionModels.PredictionDataArrayDirect> {
+        const result = await this.HttpAction({
+            verb: "POST",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
+            baseUrl: `${this._baseUrl}/predictDirect?${toQueryString(params)}`,
+            body: modelData,
+        });
+        return result as TrendPredictionModels.PredictionDataArrayDirect;
     }
 
     /**
@@ -112,9 +201,59 @@ export class TrendPredictionClient extends SdkClient {
             gateway: this.GetGateway(),
             authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/trainAndPredict`,
-            body: modelData
+            body: modelData,
         });
         return result as TrendPredictionModels.PredictionDataArray;
+    }
+
+    /**
+     * Fits a regression model on the training dataset and predicts future values of a
+     * given output variable using the trained regression model.
+     *
+     * @param {TrendPredictionModels.TrainPredictBodyDirect} modelData
+     * @param {{
+     *             trainFrom: Date;
+     *             trainTo: Date;
+     *             predictFrom: Date;
+     *             predictTo: Date;
+     *         }} params
+     * @param params.trainFrom Beginning of the time range to be retrieved (exclusive)
+     * @param params.trainTo End of the time range to be retrieved (exclusive)
+     * @param params.predictFrom Beginning of the time range to be retrieved (exclusive)
+     * @param params.predictTo End of the time range to be retrieved (exclusive)
+     *
+     * * Data structure with two parts - modelConfiguration and metadataConfiguration.
+     *
+     * * modelConfiguration
+     * contains the information necessary for configuring the regression model to be trained
+     * (e.g., the degree of a polynomial in case of polynomial regression).
+     *
+     * * metadataConfiguration
+     * specifies which variables are the input variables (regressors), and which one is the output variable
+     * (regressand) of the regression model. In order to specify time as one of the input variables,
+     * set propertyName equal to timestamp.
+     *
+     * @returns {Promise<TrendPredictionModels.PredictionDataArrayDirect>}
+     *
+     * @memberOf TrendPredictionClient
+     */
+    public async TrainAndPredictDirect(
+        modelData: TrendPredictionModels.TrainPredictBodyDirect,
+        params: {
+            trainFrom: Date;
+            trainTo: Date;
+            predictFrom: Date;
+            predictTo: Date;
+        }
+    ): Promise<TrendPredictionModels.PredictionDataArrayDirect> {
+        const result = await this.HttpAction({
+            verb: "POST",
+            gateway: this.GetGateway(),
+            authorization: await this.GetToken(),
+            baseUrl: `${this._baseUrl}/trainAndPredictDirect?${toQueryString(params)}`,
+            body: modelData,
+        });
+        return result as TrendPredictionModels.PredictionDataArrayDirect;
     }
 
     /**
@@ -148,7 +287,7 @@ export class TrendPredictionClient extends SdkClient {
             gateway: this.GetGateway(),
             authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/models?${qs}`,
-            message: "GetModels"
+            message: "GetModels",
         })) as TrendPredictionModels.ModelDto[];
     }
 
@@ -167,7 +306,7 @@ export class TrendPredictionClient extends SdkClient {
             gateway: this.GetGateway(),
             authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/models/${id}`,
-            message: "GetModel"
+            message: "GetModel",
         })) as TrendPredictionModels.ModelDto;
     }
 
@@ -188,7 +327,7 @@ export class TrendPredictionClient extends SdkClient {
             authorization: await this.GetToken(),
             baseUrl: `${this._baseUrl}/models/${id}`,
             message: "DeleteModel",
-            noResponse: true
+            noResponse: true,
         });
     }
 }


### PR DESCRIPTION
Closes #204

TrainAndPredictDirect data structure has two parts, not four as written in the documentation.